### PR TITLE
Strip NAME prefix.

### DIFF
--- a/modules/catalog/src/main/scala/lucuma/catalog/CatalogAdapter.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/CatalogAdapter.scala
@@ -39,6 +39,10 @@ sealed trait CatalogAdapter {
   def rvField: FieldId    = FieldId.unsafeFrom("RV_VALUE", VoTableParser.UCD_RV)
   def plxField: FieldId   = FieldId.unsafeFrom("PLX_VALUE", VoTableParser.UCD_PLX)
 
+  // Parse nameField. In Simbad, this can include a prefix, e.g. "NAME "
+  def parseName(entries: Map[FieldId, String]): Option[String] =
+    entries.get(nameField)
+
   // From a Field extract the band from either the field id or the UCD
   protected def fieldToBand(field: FieldId): Option[MagnitudeBand]
 
@@ -242,6 +246,9 @@ object CatalogAdapter {
     val decField                 = FieldId.unsafeFrom("DEC_d", VoTableParser.UCD_DEC)
     override val pmRaField       = FieldId.unsafeFrom("PMRA", VoTableParser.UCD_PMRA)
     override val pmDecField      = FieldId.unsafeFrom("PMDEC", VoTableParser.UCD_PMDEC)
+
+    override def parseName(entries: Map[FieldId, String]): Option[String] =
+      super.parseName(entries).map(_.stripPrefix("NAME "))
 
     override def ignoreMagnitudeField(v: FieldId): Boolean =
       !v.id.value.toLowerCase.startsWith("flux") ||

--- a/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
@@ -112,10 +112,7 @@ trait VoTableParser {
 
     def parseName: ValidatedNec[CatalogProblem, NonEmptyString] =
       Validated
-        .fromOption(entries
-                      .get(adapter.nameField)
-                      .map(_.stripPrefix("NAME "))
-                      .flatMap(refineV[NonEmpty](_).toOption),
+        .fromOption(adapter.parseName(entries).flatMap(refineV[NonEmpty](_).toOption),
                     MissingValue(adapter.nameField)
         )
         .toValidatedNec

--- a/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
@@ -112,7 +112,10 @@ trait VoTableParser {
 
     def parseName: ValidatedNec[CatalogProblem, NonEmptyString] =
       Validated
-        .fromOption(entries.get(adapter.nameField).flatMap(refineV[NonEmpty](_).toOption),
+        .fromOption(entries
+                      .get(adapter.nameField)
+                      .map(_.stripPrefix("NAME "))
+                      .flatMap(refineV[NonEmpty](_).toOption),
                     MissingValue(adapter.nameField)
         )
         .toValidatedNec

--- a/modules/tests/jvm/src/main/resources/simbad-vega-name.xml
+++ b/modules/tests/jvm/src/main/resources/simbad-vega-name.xml
@@ -1,0 +1,724 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.2 http://www.ivoa.net/xml/VOTable/v1.2" version="1.2">
+<DEFINITIONS>
+<COOSYS ID="COOSYS" equinox="2000" epoch="J2000" system="ICRS"/>
+</DEFINITIONS>
+<RESOURCE name="Simbad query" type="results">
+<TABLE ID="simbad" name="simbad query"><DESCRIPTION>... query string ...</DESCRIPTION>
+<FIELD ID="TYPED_ID" name="TYPED_ID" datatype="char" width="25" ucd="meta.id" arraysize="*">
+<DESCRIPTION>Raw identifier as typed in the query</DESCRIPTION>
+</FIELD>
+<FIELD ID="ANG_DIST" name="ANG_DIST" datatype="float" precision="4" width="8" ucd="pos.posAng" unit="arcsec">
+<DESCRIPTION>Angular distance from the center</DESCRIPTION>
+</FIELD>
+<FIELD ID="MAIN_ID" name="MAIN_ID" datatype="char" width="22" ucd="meta.id;meta.main" arraysize="*">
+<DESCRIPTION>Main identifier for an object</DESCRIPTION>
+<LINK value="${MAIN_ID}" href="http://simbad.u-strasbg.fr/simbad/sim-id?Ident=${MAIN_ID}&amp;NbIdent=1"/>
+</FIELD>
+<FIELD ID="OTYPE_S" name="OTYPE_S" datatype="char" width="8" ucd="src.class" arraysize="*">
+<DESCRIPTION>Object type</DESCRIPTION>
+<LINK href="http://simbad.u-strasbg.fr/simbad/sim-display?data=otypes"/>
+</FIELD>
+<FIELD ID="RA_d" name="RA_d" datatype="double" precision="8" width="11" ucd="pos.eq.ra;meta.main" unit="deg">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="DEC_d" name="DEC_d" datatype="double" precision="8" width="12" ucd="pos.eq.dec;meta.main" unit="deg">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_MAJA_d" name="COO_ERR_MAJA_d" datatype="float" precision="3" width="6" ucd="phys.angSize.smajAxis;pos.errorEllipse;pos.eq" unit="mas">
+<DESCRIPTION>Coordinate error major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_MINA_d" name="COO_ERR_MINA_d" datatype="float" precision="3" width="6" ucd="phys.angSize.sminAxis;pos.errorEllipse;pos.eq" unit="mas">
+<DESCRIPTION>Coordinate error minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_ANGLE_d" name="COO_ERR_ANGLE_d" datatype="short" width="3" ucd="pos.posAng;pos.errorEllipse;pos.eq" unit="deg">
+<DESCRIPTION>Coordinate error angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="PMRA" name="PMRA" datatype="double" precision="3" width="9" ucd="pos.pm;pos.eq.ra" unit="mas.yr-1">
+<DESCRIPTION>Proper motion in RA</DESCRIPTION>
+</FIELD>
+<FIELD ID="PMDEC" name="PMDEC" datatype="double" precision="3" width="9" ucd="pos.pm;pos.eq.dec" unit="mas.yr-1">
+<DESCRIPTION>Proper motion in DEC</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_MAJA" name="PM_ERR_MAJA" datatype="float" precision="3" width="5" ucd="phys.angSize.smajAxis;pos.errorEllipse;pos.pm" unit="mas.yr-1">
+<DESCRIPTION>Proper motion error major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_MINA" name="PM_ERR_MINA" datatype="float" precision="3" width="5" ucd="phys.angSize.sminAxis;pos.errorEllipse;pos.pm" unit="mas.yr-1">
+<DESCRIPTION>Proper motion error minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_ANGLE" name="PM_ERR_ANGLE" datatype="short" width="3" ucd="pos.posAng;pos.errorEllipse;pos.pm" unit="deg">
+<DESCRIPTION>Proper motion error angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_VALUE" name="PLX_VALUE" datatype="double" precision="3" width="9" ucd="pos.parallax.trig" unit="mas">
+<DESCRIPTION>Parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="RV_VALUE" name="RV_VALUE" datatype="double" precision="3" ucd="spect.dopplerVeloc.opt" unit="km.s-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_VALUE" name="Z_VALUE" datatype="double" precision="7" ucd="src.redshift">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_MAJAXIS" name="GALDIM_MAJAXIS" datatype="float" width="4" ucd="phys.angSize.smajAxis" unit="arcmin">
+<DESCRIPTION>Angular size major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_MINAXIS" name="GALDIM_MINAXIS" datatype="float" width="4" ucd="phys.angSize.sminAxis" unit="arcmin">
+<DESCRIPTION>Angular size minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_ANGLE" name="GALDIM_ANGLE" datatype="short" width="3" ucd="pos.posAng" unit="deg">
+<DESCRIPTION>Galaxy ellipse angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="SP_TYPE" name="SP_TYPE" datatype="char" width="6" ucd="src.spType" arraysize="*">
+<DESCRIPTION>MK spectral type</DESCRIPTION>
+</FIELD>
+<FIELD ID="MORPH_TYPE" name="MORPH_TYPE" datatype="char" width="20" ucd="src.morph.type" arraysize="*">
+<DESCRIPTION>Morphological type</DESCRIPTION>
+</FIELD>
+<FIELD ID="NB_REF" name="NB_REF" datatype="int" width="4" ucd="meta.bib;meta.number">
+<DESCRIPTION>number of references</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_U" name="FILTER_NAME_U" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_U" name="FLUX_U" datatype="float" ucd="phot.mag;em.opt.U" unit="mag">
+<DESCRIPTION>Magnitude U</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_U" name="FLUX_ERROR_U" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_U" name="FLUX_SYSTEM_U" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_U" name="FLUX_BIBCODE_U" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_U" name="FLUX_VAR_U" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_U" name="FLUX_MULT_U" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_U" name="FLUX_QUAL_U" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_U" name="FLUX_UNIT_U" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_B" name="FILTER_NAME_B" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_B" name="FLUX_B" datatype="float" ucd="phot.mag;em.opt.B" unit="mag">
+<DESCRIPTION>Magnitude B</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_B" name="FLUX_ERROR_B" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_B" name="FLUX_SYSTEM_B" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_B" name="FLUX_BIBCODE_B" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_B" name="FLUX_VAR_B" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_B" name="FLUX_MULT_B" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_B" name="FLUX_QUAL_B" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_B" name="FLUX_UNIT_B" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_V" name="FILTER_NAME_V" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_V" name="FLUX_V" datatype="float" ucd="phot.mag;em.opt.V" unit="mag">
+<DESCRIPTION>Magnitude V</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_V" name="FLUX_ERROR_V" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_V" name="FLUX_SYSTEM_V" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_V" name="FLUX_BIBCODE_V" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_V" name="FLUX_VAR_V" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_V" name="FLUX_MULT_V" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_V" name="FLUX_QUAL_V" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_V" name="FLUX_UNIT_V" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_R" name="FILTER_NAME_R" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_R" name="FLUX_R" datatype="float" ucd="phot.mag;em.opt.R" unit="mag">
+<DESCRIPTION>Magnitude R</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_R" name="FLUX_ERROR_R" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_R" name="FLUX_SYSTEM_R" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_R" name="FLUX_BIBCODE_R" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_R" name="FLUX_VAR_R" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_R" name="FLUX_MULT_R" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_R" name="FLUX_QUAL_R" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_R" name="FLUX_UNIT_R" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_I" name="FILTER_NAME_I" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_I" name="FLUX_I" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude I</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_I" name="FLUX_ERROR_I" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_I" name="FLUX_SYSTEM_I" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_I" name="FLUX_BIBCODE_I" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_I" name="FLUX_VAR_I" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_I" name="FLUX_MULT_I" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_I" name="FLUX_QUAL_I" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_I" name="FLUX_UNIT_I" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_J" name="FILTER_NAME_J" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_J" name="FLUX_J" datatype="float" ucd="phot.mag;em.IR.J" unit="mag">
+<DESCRIPTION>Magnitude J</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_J" name="FLUX_ERROR_J" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_J" name="FLUX_SYSTEM_J" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_J" name="FLUX_BIBCODE_J" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_J" name="FLUX_VAR_J" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_J" name="FLUX_MULT_J" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_J" name="FLUX_QUAL_J" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_J" name="FLUX_UNIT_J" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_H" name="FILTER_NAME_H" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_H" name="FLUX_H" datatype="float" ucd="phot.mag;em.IR.H" unit="mag">
+<DESCRIPTION>Magnitude H</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_H" name="FLUX_ERROR_H" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_H" name="FLUX_SYSTEM_H" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_H" name="FLUX_BIBCODE_H" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_H" name="FLUX_VAR_H" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_H" name="FLUX_MULT_H" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_H" name="FLUX_QUAL_H" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_H" name="FLUX_UNIT_H" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_K" name="FILTER_NAME_K" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_K" name="FLUX_K" datatype="float" ucd="phot.mag;em.IR.K" unit="mag">
+<DESCRIPTION>Magnitude K</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_K" name="FLUX_ERROR_K" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_K" name="FLUX_SYSTEM_K" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_K" name="FLUX_BIBCODE_K" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_K" name="FLUX_VAR_K" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_K" name="FLUX_MULT_K" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_K" name="FLUX_QUAL_K" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_K" name="FLUX_UNIT_K" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_u" name="FILTER_NAME_u" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_u" name="FLUX_u" datatype="float" ucd="phot.mag;em.opt.U" unit="mag">
+<DESCRIPTION>Magnitude SDSS u</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_u" name="FLUX_ERROR_u" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_u" name="FLUX_SYSTEM_u" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_u" name="FLUX_BIBCODE_u" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_u" name="FLUX_VAR_u" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_u" name="FLUX_MULT_u" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_u" name="FLUX_QUAL_u" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_u" name="FLUX_UNIT_u" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_g" name="FILTER_NAME_g" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_g" name="FLUX_g" datatype="float" ucd="phot.mag;em.opt.B" unit="mag">
+<DESCRIPTION>Magnitude SDSS g</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_g" name="FLUX_ERROR_g" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_g" name="FLUX_SYSTEM_g" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_g" name="FLUX_BIBCODE_g" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_g" name="FLUX_VAR_g" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_g" name="FLUX_MULT_g" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_g" name="FLUX_QUAL_g" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_g" name="FLUX_UNIT_g" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_r" name="FILTER_NAME_r" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_r" name="FLUX_r" datatype="float" ucd="phot.mag;em.opt.R" unit="mag">
+<DESCRIPTION>Magnitude SDSS r</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_r" name="FLUX_ERROR_r" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_r" name="FLUX_SYSTEM_r" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_r" name="FLUX_BIBCODE_r" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_r" name="FLUX_VAR_r" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_r" name="FLUX_MULT_r" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_r" name="FLUX_QUAL_r" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_r" name="FLUX_UNIT_r" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_i" name="FILTER_NAME_i" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_i" name="FLUX_i" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude SDSS i</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_i" name="FLUX_ERROR_i" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_i" name="FLUX_SYSTEM_i" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_i" name="FLUX_BIBCODE_i" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_i" name="FLUX_VAR_i" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_i" name="FLUX_MULT_i" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_i" name="FLUX_QUAL_i" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_i" name="FLUX_UNIT_i" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_z" name="FILTER_NAME_z" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_z" name="FLUX_z" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude SDSS z</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_z" name="FLUX_ERROR_z" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_SYSTEM_z" name="FLUX_SYSTEM_z" datatype="char" ucd="instr.precision;phot.flux" arraysize="*">
+<DESCRIPTION>flux system A=AB V=Vega</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_z" name="FLUX_BIBCODE_z" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_z" name="FLUX_VAR_z" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_z" name="FLUX_MULT_z" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_z" name="FLUX_QUAL_z" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_z" name="FLUX_UNIT_z" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="Diameter_diameter" name="Diameter:diameter" datatype="double" precision="2" width="8" ucd="PHYS.ANGSIZE">
+<DESCRIPTION>Diameter value</DESCRIPTION>
+</FIELD>
+<FIELD ID="Diameter_Q" name="Diameter:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="Diameter_unit" name="Diameter:unit" datatype="char" width="4" ucd="META.UNIT" arraysize="4">
+<DESCRIPTION>Unit (mas/km)</DESCRIPTION>
+</FIELD>
+<FIELD ID="Diameter_error" name="Diameter:error" datatype="double" precision="2" width="8" ucd="STAT.ERROR">
+<DESCRIPTION>Error</DESCRIPTION>
+</FIELD>
+<FIELD ID="Diameter_filter" name="Diameter:filter" datatype="char" width="8" ucd="INSTR.FILTER" arraysize="8">
+<DESCRIPTION>filter or wavelength</DESCRIPTION>
+</FIELD>
+<FIELD ID="Diameter_method" name="Diameter:method" datatype="char" width="8" ucd="INSTR.SETUP" arraysize="8">
+<DESCRIPTION>calculation method</DESCRIPTION>
+</FIELD>
+<FIELD ID="Diameter_bibcode" name="Diameter:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Distance_distance" name="Distance:distance" datatype="double" precision="4" width="10" ucd="POS.DISTANCE">
+<DESCRIPTION>Distance value</DESCRIPTION>
+</FIELD>
+<FIELD ID="Distance_Q" name="Distance:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="Distance_unit" name="Distance:unit" datatype="char" width="4" ucd="META.UNIT" arraysize="4">
+<DESCRIPTION>Unit (pc,kpc or Mpc)</DESCRIPTION>
+</FIELD>
+<FIELD ID="Distance_merr" name="Distance:merr" datatype="double" precision="4" width="9" ucd="STAT.ERROR">
+<DESCRIPTION>minus error</DESCRIPTION>
+</FIELD>
+<FIELD ID="Distance_perr" name="Distance:perr" datatype="double" precision="4" width="9" ucd="STAT.ERROR">
+<DESCRIPTION>plus error</DESCRIPTION>
+</FIELD>
+<FIELD ID="Distance_method" name="Distance:method" datatype="char" width="8" ucd="INSTR.SETUP" arraysize="8">
+<DESCRIPTION>distance calculation method</DESCRIPTION>
+</FIELD>
+<FIELD ID="Distance_bibcode" name="Distance:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_Teff" name="Fe_H:Teff" datatype="int" width="5" ucd="PHYS.TEMPERATURE.EFFECTIVE" unit="unit-degK">
+<DESCRIPTION>Effective Temperature</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_log_g" name="Fe_H:log_g" datatype="float" precision="4" width="6" ucd="PHYS.GRAVITY" unit="cm/s**2">
+<DESCRIPTION>Decimal logarithm of the surface gravity</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_Fe_H" name="Fe_H:Fe_H" datatype="float" precision="3" width="6" ucd="PHYS.ABUND.FE">
+<DESCRIPTION>Metallicity index relative to the Sun</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_flag" name="Fe_H:flag" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Flag on the [Fe/H] value</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_CompStar" name="Fe_H:CompStar" datatype="char" width="9" ucd="META.ID" arraysize="*">
+<DESCRIPTION>Designates the comparison star from which the [Fe/H] value was obtained</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_CatNo" name="Fe_H:CatNo" datatype="char" width="5" ucd="META.ID;META.MAIN" arraysize="5">
+<DESCRIPTION>Star in the Cayrel et al. (1997A&amp;AS..124..299C) compilation</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_bibcode" name="Fe_H:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_ObsId" name="Herschel:ObsId" datatype="char" width="10" ucd="META.ID;META.MAIN" arraysize="10">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_alpha" name="Herschel:alpha" datatype="char" width="11" ucd="POS.EQ.RA;META.MAIN" arraysize="11" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_delta" name="Herschel:delta" datatype="char" width="11" ucd="POS.EQ.DEC;META.MAIN" arraysize="11" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_plx" name="PLX:plx" datatype="float" precision="6" width="11" ucd="POS.PARALLAX.TRIG" unit="mas">
+<DESCRIPTION>Parallaxe</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_me" name="PLX:me" datatype="float" precision="6" width="11" ucd="STAT.ERROR" unit="mas">
+<DESCRIPTION>sigma{plx}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_R" name="PLX:R" datatype="char" width="2" ucd="META.ID;INSTR.OBSTY" arraysize="2">
+<DESCRIPTION>Observatory code</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_bibcode" name="PLX:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_pmra" name="PM:pmra" datatype="float" precision="3" width="9" ucd="POS.PM;POS.EQ.RA" unit="mas.yr-1">
+<DESCRIPTION>Proper motion R.A.</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_me_pmra" name="PM:me_pmra" datatype="float" precision="3" width="9" ucd="STAT.ERROR" unit="mas.yr-1">
+<DESCRIPTION>sigma{pm-ra}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_pmde" name="PM:pmde" datatype="float" precision="3" width="9" ucd="POS.PM;POS.EQ.DEC" unit="mas.yr-1">
+<DESCRIPTION>Proper motion DEC.</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_me_pmde" name="PM:me_pmde" datatype="float" precision="3" width="9" ucd="STAT.ERROR" unit="mas.yr-1">
+<DESCRIPTION>sigma{pm-de}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_system" name="PM:system" datatype="char" width="4" ucd="POS.FRAME" arraysize="4">
+<DESCRIPTION>coordinates system designation</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_bibcode" name="PM:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_upVsini" name="ROT:upVsini" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Vsini</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_Vsini" name="ROT:Vsini" datatype="float" precision="2" width="6" ucd="PHYS.VELOC.ROTAT" unit="km.s-1">
+<DESCRIPTION>V sini</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_err" name="ROT:err" datatype="float" precision="2" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>error</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_mes" name="ROT:mes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_qual" name="ROT:qual" datatype="char" width="1" ucd="CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_bibcode" name="ROT:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__vartyp" name="V*:vartyp" datatype="char" width="16" ucd="META.CODE;SRC.VAR" arraysize="16">
+<DESCRIPTION>Type of variability</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__LoVmax" name="V*:LoVmax" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Upper limit flag for Vmax</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__Vmax" name="V*:Vmax" datatype="float" precision="6" width="10" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Maximum of brightness</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_Vmax" name="V*:R_Vmax" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__magtyp" name="V*:magtyp" datatype="char" width="1" ucd="META.ID;PHOT" arraysize="1">
+<DESCRIPTION>Magnitude type</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__UpVmin" name="V*:UpVmin" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Lower limit flag for Vmin</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__Vmin" name="V*:Vmin" datatype="float" precision="6" width="10" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Minimum of brightness</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_Vmin" name="V*:R_Vmin" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag for Vmin</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__UpPeriod" name="V*:UpPeriod" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Lower limit flag for the period</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__period" name="V*:period" datatype="double" precision="6" width="12" ucd="TIME.PERIOD" unit="day">
+<DESCRIPTION>Period</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_period" name="V*:R_period" datatype="char" width="2" ucd="META.CODE.ERROR" arraysize="2">
+<DESCRIPTION>Uncertainty flag on period (:+)</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__epoch" name="V*:epoch" datatype="double" precision="4" width="13" ucd="TIME.EPOCH" unit="day">
+<DESCRIPTION>Epoch of maximum or minimum</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_epoch" name="V*:R_epoch" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty on epoch (:)</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__D_rt" name="V*:D_rt" datatype="float" precision="1" width="4" ucd="TIME.INTERVAL">
+<DESCRIPTION>Raising time for all other variable types</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_D_rt" name="V*:R_D_rt" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag on raising time</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__bibcode" name="V*:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_type" name="velocities:type" datatype="char" width="3" ucd="META.CODE;SPECT.DOPPLERVELOC" arraysize="3">
+<DESCRIPTION>velocity type (v, z or cz)</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_Value" name="velocities:Value" datatype="double" precision="6" width="11" ucd="SPECT.DOPPLERVELOC">
+<DESCRIPTION>Velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_R" name="velocities:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>colon is uncertain question mark is questionable</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_me" name="velocities:me" datatype="double" precision="6" width="9" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(Value)</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_Acc" name="velocities:Acc" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_Nmes" name="velocities:Nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_nat" name="velocities:nat" datatype="char" width="2" ucd="META.CODE;SPECT.DOPPLERVELOC" arraysize="2">
+<DESCRIPTION>nature of the measurement</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_Q" name="velocities:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_dom" name="velocities:dom" datatype="char" width="4" ucd="EM.WL.CENTRAL;SPECT.DOPPLERVELOC" arraysize="4">
+<DESCRIPTION>Wavelength domain (Rad,mm,IR,Opt,UV,XRay,Gam)</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_res" name="velocities:res" datatype="float" precision="4" width="10" ucd="SPECT.RESOLUTION">
+<DESCRIPTION>Resolution</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_d" name="velocities:d" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>D</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_Date" name="velocities:Date" datatype="double" precision="3" width="10" ucd="TIME.EPOCH">
+<DESCRIPTION>Observation date</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_Rem" name="velocities:Rem" datatype="char" width="7" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_Origin" name="velocities:Origin" datatype="char" width="2" ucd="META.NOTE" arraysize="2">
+<DESCRIPTION>Origin of the radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="velocities_bibcode" name="velocities:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_TDT" name="ISO:TDT" datatype="char" width="8" ucd="META.ID;META.MAIN" arraysize="8">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_alpha" name="ISO:alpha" datatype="double" precision="4" width="8" ucd="POS.EQ.RA;META.MAIN" unit="deg">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_delta" name="ISO:delta" datatype="double" precision="4" width="8" ucd="POS.EQ.DEC;META.MAIN" unit="deg">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Homogenized_Name" name="IUE:Homogenized_Name" datatype="char" width="16" ucd="META.ID;META.MAIN" arraysize="*">
+<DESCRIPTION>Homogenized Name</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ComplID" name="IUE:ComplID" datatype="char" width="12" ucd="META.ID" arraysize="*">
+<DESCRIPTION>Complementary Identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_PROG" name="IUE:PROG" datatype="char" width="5" ucd="META.ID;OBS" arraysize="5">
+<DESCRIPTION>Observing Program Identification</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CL" name="IUE:CL" datatype="int" width="2" ucd="SRC.CLASS">
+<DESCRIPTION>IUE class code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_D" name="IUE:D" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Dispersion code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CAM" name="IUE:CAM" datatype="char" width="3" ucd="META.ID;INSTR" arraysize="3">
+<DESCRIPTION>Camera id</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_IMAGE" name="IUE:IMAGE" datatype="int" width="5" ucd="OBS.IMAGE">
+<DESCRIPTION>Image number</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_A" name="IUE:A" datatype="char" width="1" ucd="INSTR.FOV" arraysize="1">
+<DESCRIPTION>Aperture designation code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_FES" name="IUE:FES" datatype="int" width="5" ucd="PHOT.COUNT;EM.OPT">
+<DESCRIPTION>FES count</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_MD" name="IUE:MD" datatype="char" width="2" ucd="META.CODE" arraysize="2">
+<DESCRIPTION>FES mode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ObsDate" name="IUE:ObsDate" datatype="char" width="6" ucd="TIME.EPOCH" arraysize="6">
+<DESCRIPTION>Observation date</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Time" name="IUE:Time" datatype="char" width="6" ucd="TIME.EPOCH" arraysize="6">
+<DESCRIPTION>Observation time</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ExpTim" name="IUE:ExpTim" datatype="int" width="6" ucd="TIME.EXPO" unit="sec">
+<DESCRIPTION>Effective exposure time</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_m" name="IUE:m" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Abnormality code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CEB" name="IUE:CEB" datatype="char" width="3" ucd="META.CODE.CLASS" arraysize="3">
+<DESCRIPTION>Exposure quality code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_S" name="IUE:S" datatype="char" width="1" ucd="META.FLAG;INSTR.TEL" arraysize="1">
+<DESCRIPTION>Station (V=Vilspa/G=Goddard)</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Comments" name="IUE:Comments" datatype="char" width="20" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Comments</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_F" name="IUE:F" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_bibcode" name="IUE:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="XMM_Obsno" name="XMM:Obsno" datatype="char" width="10" ucd="META.ID;META.MAIN" arraysize="10">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="OID4" name="OID4" datatype="char" width="10" ucd="meta.record;meta.id" arraysize="*">
+<DESCRIPTION>Object internal identifier</DESCRIPTION>
+</FIELD>
+<DATA>
+<TABLEDATA>
+<TR><TD>NAME Vega</TD><TD></TD><TD>* alf Lyr</TD><TD>PulsV*delSct</TD><TD>279.23473479</TD><TD>+38.78368896</TD><TD>3.51</TD><TD>2.81</TD><TD>90</TD><TD>200.94</TD><TD>286.23</TD><TD>0.32</TD><TD>0.40</TD><TD>0</TD><TD>130.23</TD><TD>-20.60</TD><TD>-0.000069</TD><TD></TD><TD></TD><TD></TD><TD>A0Va</TD><TD></TD><TD>2558</TD><TD>U</TD><TD>0.03</TD><TD></TD><TD>Vega</TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>U</TD><TD>B</TD><TD>0.03</TD><TD></TD><TD>Vega</TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>B</TD><TD>V</TD><TD>0.03</TD><TD></TD><TD>Vega</TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>V</TD><TD>R</TD><TD>0.07</TD><TD></TD><TD>Vega</TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>R</TD><TD>I</TD><TD>0.10</TD><TD></TD><TD>Vega</TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>I</TD><TD>J</TD><TD>-0.177</TD><TD>0.206</TD><TD>Vega</TD><TD>2003yCat.2246....0C</TD><TD></TD><TD></TD><TD>D</TD><TD>J</TD><TD>H</TD><TD>-0.029</TD><TD>0.146</TD><TD>Vega</TD><TD>2003yCat.2246....0C</TD><TD></TD><TD></TD><TD>D</TD><TD>H</TD><TD>K</TD><TD>0.129</TD><TD>0.186</TD><TD>Vega</TD><TD>2003yCat.2246....0C</TD><TD></TD><TD></TD><TD>D</TD><TD>K</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>1.80E+06</TD><TD></TD><TD>km</TD><TD></TD><TD></TD><TD></TD><TD>2007ApJ...660.1556R</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>9830</TD><TD></TD><TD></TD><TD></TD><TD>SUN</TD><TD></TD><TD>1995A&amp;AS..110..553S</TD><TD>1342186861</TD><TD>18 36 55.70</TD><TD>+38 46 56.4</TD><TD>128.93</TD><TD>0.55</TD><TD></TD><TD>1997A&amp;A...323L..49P</TD><TD>+201.85</TD><TD>0.14</TD><TD>+285.46</TD><TD>0.13</TD><TD>ICRS</TD><TD>2008AJ....136..452G</TD><TD></TD><TD>24</TD><TD></TD><TD>0</TD><TD>D</TD><TD>2007A&amp;A...463..671R</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>v</TD><TD>-13.9</TD><TD></TD><TD></TD><TD></TD><TD>308</TD><TD>s</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>1995A&amp;AS..114..269D</TD><TD>50301801</TD><TD>279.3998</TD><TD>+38.9664</TD><TD>HD 172167</TD><TD></TD><TD>PHCAL</TD><TD>30</TD><TD>L</TD><TD>SWP</TD><TD>30549</TD><TD>L</TD><TD>15984</TD><TD>FU</TD><TD>870317</TD><TD>004700</TD><TD>000001</TD><TD>T</TD><TD>500</TD><TD>G</TD><TD>C=180,B=15</TD><TD>*</TD><TD>1996IUEML.C......0I</TD><TD></TD><TD>@2900336</TD></TR>
+
+</TABLEDATA>
+
+</DATA>
+</TABLE>
+</RESOURCE>
+</VOTABLE>


### PR DESCRIPTION
When performing wildcard searches in Simbad, name matches (as opposed to id matches) will have the prefix `NAME ` in the returned name (`TYPED_ID` field). This PR strips such prefix from the returned results.