### PR TITLE
Allow empty ucds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val scalaXmlVersion         = "2.0.1"
 Global / onChangedBuildSource   := ReloadOnSourceChanges
 Global / scalacOptions += "-Ymacro-annotations"
 
-ThisBuild / tlBaseVersion       := "0.10"
+ThisBuild / tlBaseVersion       := "0.11"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val root = tlCrossRootProject.aggregate(catalog, testkit, tests)

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ lazy val catalog = crossProject(JVMPlatform, JSPlatform)
       "edu.gemini"    %%% "lucuma-core"   % lucumaCoreVersion,
       "org.typelevel" %%% "cats-core"     % catsVersion,
       "dev.optics"    %%% "monocle-core"  % monocleVersion,
-      "dev.optics"    %%% "monocle-macro" % monocleVersion,
       "dev.optics"    %%% "monocle-state" % monocleVersion,
       "eu.timepit"    %%% "refined"       % refinedVersion,
       "eu.timepit"    %%% "refined-cats"  % refinedVersion

--- a/modules/catalog/src/main/scala/lucuma/catalog/CatalogProblem.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/CatalogProblem.scala
@@ -3,7 +3,7 @@
 
 package lucuma.catalog
 
-import cats.implicits._
+import cats.syntax.all._
 import lucuma.core.enum.CatalogName
 
 /** Indicates an issue parsing the targets, e.g. missing values, bad format, etc. */
@@ -14,52 +14,52 @@ sealed trait CatalogProblem extends Throwable with Product with Serializable {
 }
 
 object CatalogProblem {
-  case class ValidationError(catalog: CatalogName)      extends CatalogProblem {
+  case class ValidationError(catalog: CatalogName)              extends CatalogProblem {
     val displayValue = s"Invalid response from $catalog"
   }
-  case class InvalidFieldId(id: String)                 extends CatalogProblem {
+  case class InvalidFieldId(id: String)                         extends CatalogProblem {
     val displayValue = s"Invalid field id: '$id'"
   }
-  case class UnknownXmlTag(tag: String)                 extends CatalogProblem {
+  case class UnknownXmlTag(tag: String)                         extends CatalogProblem {
     val displayValue = s"Unknown tag: '$tag'"
   }
-  case class MissingXmlTag(tag: String)                 extends CatalogProblem {
+  case class MissingXmlTag(tag: String)                         extends CatalogProblem {
     val displayValue = s"Missing tag: '$tag'"
   }
-  case class MissingXmlAttribute(attr: String)          extends CatalogProblem {
+  case class MissingXmlAttribute(attr: String)                  extends CatalogProblem {
     val displayValue = s"Missing attr: '$attr'"
   }
-  case class InvalidUcd(ucd: String)                    extends CatalogProblem {
+  case class InvalidUcd(ucd: String)                            extends CatalogProblem {
     val displayValue = s"Invalid ucd: '$ucd'"
   }
-  case class GenericError(msg: String)                  extends CatalogProblem {
+  case class GenericError(msg: String)                          extends CatalogProblem {
     val displayValue = msg
   }
-  case class UnexpectedTag(tag: String)                 extends CatalogProblem {
+  case class UnexpectedTag(tag: String)                         extends CatalogProblem {
     val displayValue = s"Unexpected tag $tag"
   }
-  case object NoFieldsFound                             extends CatalogProblem {
+  case object NoFieldsFound                                     extends CatalogProblem {
     val displayValue = s"No fields defined"
   }
-  case object ExtraRow                                  extends CatalogProblem {
+  case object ExtraRow                                          extends CatalogProblem {
     val displayValue = s"Extra row in the data"
   }
-  case object MissingRow                                extends CatalogProblem {
+  case object MissingRow                                        extends CatalogProblem {
     val displayValue = s"Missing row in the data"
   }
-  case class MissingValue(field: FieldId)               extends CatalogProblem {
-    val displayValue = s"Missing required field ${field.id}"
+  case class MissingValue(field: FieldId)                       extends CatalogProblem {
+    val displayValue = s"Missing required field '${field.id}'"
   }
-  case class FieldValueProblem(ucd: Ucd, value: String) extends CatalogProblem {
-    val displayValue = s"Error parsing field $ucd with value $value"
+  case class FieldValueProblem(ucd: Option[Ucd], value: String) extends CatalogProblem {
+    val displayValue = s"Error parsing field ${ucd.foldMap(_.toString)} with value $value"
   }
-  case class UnsupportedField(field: FieldId)           extends CatalogProblem {
+  case class UnsupportedField(field: FieldId)                   extends CatalogProblem {
     val displayValue = s"Unsupported field $field"
   }
-  case class UnmatchedField(ucd: Ucd)                   extends CatalogProblem {
-    val displayValue = s"Unmatched field $ucd"
+  case class UnmatchedField(ucd: Option[Ucd])                   extends CatalogProblem {
+    val displayValue = s"Unmatched field ${ucd.foldMap(_.toString)}"
   }
-  case object UnknownCatalog                            extends CatalogProblem {
+  case object UnknownCatalog                                    extends CatalogProblem {
     val displayValue = s"Requested an unknown catalog"
   }
 

--- a/modules/catalog/src/main/scala/lucuma/catalog/Fields.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/Fields.scala
@@ -11,10 +11,8 @@ import eu.timepit.refined.cats._
 import eu.timepit.refined.cats.syntax._
 import eu.timepit.refined.types.string._
 import lucuma.catalog.CatalogProblem._
-import monocle.macros.Lenses
 
 /** Describes a field */
-@Lenses
 case class FieldId(id: NonEmptyString, ucd: Option[Ucd])
 
 object FieldId {
@@ -34,17 +32,14 @@ object FieldId {
   implicit val eqFieldId: Eq[FieldId] = Eq.by(x => (x.id, x.ucd))
 }
 
-@Lenses
 case class FieldDescriptor(id: FieldId, name: String)
 
 object FieldDescriptor {
   implicit val eqFieldDescriptor: Eq[FieldDescriptor] = Eq.by(x => (x.id, x.name))
 }
 
-@Lenses
 case class TableRowItem(field: FieldDescriptor, data: String)
 
-@Lenses
 case class TableRow(items: List[TableRowItem]) {
   def itemsMap: Map[FieldId, String] = items.map(i => i.field.id -> i.data).toMap
 }

--- a/modules/catalog/src/main/scala/lucuma/catalog/Fields.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/Fields.scala
@@ -15,13 +15,15 @@ import monocle.macros.Lenses
 
 /** Describes a field */
 @Lenses
-case class FieldId(id: NonEmptyString, ucd: Ucd)
+case class FieldId(id: NonEmptyString, ucd: Option[Ucd])
 
 object FieldId {
   def apply(id: String, ucd: Ucd): ValidatedNec[CatalogProblem, FieldId] =
     NonEmptyString
       .validateNec(id)
-      .bimap(_ => NonEmptyChain.one(InvalidFieldId(id)).widen[CatalogProblem], FieldId(_, ucd))
+      .bimap(_ => NonEmptyChain.one(InvalidFieldId(id)).widen[CatalogProblem],
+             FieldId(_, Some(ucd))
+      )
 
   def unsafeFrom(id: String, ucd: Ucd): FieldId =
     apply(id, ucd).getOrElse(sys.error(s"Invalid field id $id"))

--- a/modules/catalog/src/main/scala/lucuma/catalog/Ucd.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/Ucd.scala
@@ -13,11 +13,9 @@ import eu.timepit.refined.cats._
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.types.string._
 import lucuma.catalog.CatalogProblem._
-import monocle.macros.Lenses
 
 import scala.util.matching.Regex
 
-@Lenses
 final case class Ucd(tokens: NonEmptyList[NonEmptyString]) {
   def includes(ucd: NonEmptyString): Boolean = tokens.exists(_ === ucd)
 

--- a/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
@@ -3,7 +3,6 @@
 
 package lucuma.catalog
 
-import cats._
 import cats.data.Validated._
 import cats.data._
 import cats.implicits._
@@ -17,9 +16,9 @@ import fs2.data.xml.XmlEvent._
 import fs2.data.xml._
 import lucuma.catalog.CatalogProblem._
 import lucuma.catalog._
-import lucuma.core.enum.CatalogName
 import lucuma.core.enum.StellarLibrarySpectrum
 import lucuma.core.math._
+import lucuma.core.syntax.string._
 import lucuma.core.math.units.KilometersPerSecond
 import lucuma.core.model.CatalogInfo
 import lucuma.core.model.SiderealTracking
@@ -28,19 +27,23 @@ import lucuma.core.model.SpectralDefinition
 import lucuma.core.model.Target
 import lucuma.core.model.UnnormalizedSED
 import monocle.function.Index.listIndex
-import monocle.macros.Lenses
 
 import scala.collection.immutable.SortedMap
+import monocle.Lens
+import monocle.Focus
 
-@Lenses
-private[catalog] case class PartialTableRowItem(field: FieldDescriptor)
+final case class PartialTableRowItem(field: FieldDescriptor)
 
-@Lenses
-private[catalog] case class PartialTableRow(
+final case class PartialTableRow(
   items: List[Either[PartialTableRowItem, TableRowItem]]
 ) {
   def isComplete: Boolean  = items.forall(_.isRight)
   def toTableRow: TableRow = TableRow(items.collect { case Right(r) => r }.reverse)
+}
+
+object PartialTableRow {
+  val items: Lens[PartialTableRow, List[Either[PartialTableRowItem, TableRowItem]]] =
+    Focus[PartialTableRow](_.items)
 }
 
 object VoTableParser extends VoTableParser {

--- a/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
@@ -5,7 +5,8 @@ package lucuma.catalog
 
 import cats.data.Validated._
 import cats.data._
-import cats.implicits._
+import cats._
+import cats.syntax.all._
 import coulomb._
 import eu.timepit.refined._
 import eu.timepit.refined.cats.syntax._
@@ -16,6 +17,7 @@ import fs2.data.xml.XmlEvent._
 import fs2.data.xml._
 import lucuma.catalog.CatalogProblem._
 import lucuma.catalog._
+import lucuma.core.enum.CatalogName
 import lucuma.core.enum.StellarLibrarySpectrum
 import lucuma.core.math._
 import lucuma.core.syntax.string._

--- a/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
@@ -150,7 +150,11 @@ trait VoTableParser {
 
     def parseEpoch: ValidatedNec[CatalogProblem, Epoch] =
       Validated.validNec(
-        entries.get(adapter.epochField).flatMap(Epoch.fromString.getOption).getOrElse(Epoch.J2000)
+        (for {
+          f <- entries.get(adapter.epochField)
+          d <- f.parseDoubleOption
+          e <- Epoch.Julian.fromEpochYears(d)
+        } yield e).getOrElse(Epoch.J2000)
       )
 
     def parsePlx: ValidatedNec[CatalogProblem, Option[Parallax]] =

--- a/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/VoTableParser.scala
@@ -177,9 +177,9 @@ trait VoTableParser {
           .map(rv => RadialVelocity(rv.withUnit[KilometersPerSecond]))
 
       (entries.get(adapter.rvField), entries.get(adapter.zField)) match {
-        case (Some(rv), Some(z)) => fromRV(rv).orElse(rvFromZ(z))
-        case (Some(rv), _)       => fromRV(rv)
-        case (_, Some(z))        => rvFromZ(z)
+        case (Some(rv), Some(z)) => fromRV(rv).orElse(rvFromZ(z)).orElse(Validated.validNec(none))
+        case (Some(rv), _)       => fromRV(rv).orElse(Validated.validNec(none))
+        case (_, Some(z))        => rvFromZ(z).orElse(Validated.validNec(none))
         case _                   => Validated.validNec(none)
       }
     }

--- a/modules/catalog/src/main/scala/lucuma/catalog/package.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/package.scala
@@ -9,7 +9,7 @@ import lucuma.catalog.CatalogProblem.FieldValueProblem
 package object catalog {
 
   def parseDoubleValue(
-    ucd: Ucd,
+    ucd: Option[Ucd],
     s:   String
   ): ValidatedNec[CatalogProblem, Double] =
     Validated

--- a/modules/testkit/src/main/scala/lucuma/catalog/arb/ArbFieldId.scala
+++ b/modules/testkit/src/main/scala/lucuma/catalog/arb/ArbFieldId.scala
@@ -17,12 +17,12 @@ trait ArbFieldId {
     Arbitrary {
       for {
         i <- arbitrary[NonEmptyString]
-        u <- arbitrary[Ucd]
+        u <- arbitrary[Option[Ucd]]
       } yield FieldId(i, u)
     }
 
   implicit val cogenFieldId: Cogen[FieldId] =
-    Cogen[(String, Ucd)].contramap(x => (x.id.value, x.ucd))
+    Cogen[(String, Option[Ucd])].contramap(x => (x.id.value, x.ucd))
 
 }
 


### PR DESCRIPTION
While implementing gaia support I noted that gaia can produce synthetic fields without a ucd
This PR adds support for fields without an UCD and besides:
* Remove use of macro generated lenses
* Make parsing of epoch and rv/rz more robust
* Remove old code for UCAC4