### PR TITLE
Replace Validated by Either

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ data in a table format
 `lucuma-catalog` is centered around a single function.
 
 ```scala
-  def targets(catalog: CatalogName): Pipe[F, String, ValidatedNec[CatalogProblem, SiderealTarget]]
+  def siderealTargets(catalog: CatalogName): Pipe[F, String, EitherNec[CatalogProblem, Target.Sidereal]]
 ```
 
 The function is an `fs2` `Pipe` that will take a `Stream[F, String]`, attempt to first parse its
-xml content and then produce a stream of `SiderealTarget`s. This means we don't need to wait for the whole
+xml content and then produce a stream of `Target.Sidereal`s. This means we don't need to wait for the whole
 document to be parsed to start getting results.
 
 Note that we fail at the level of targets, this would allow to keep getting results even if one particular
@@ -41,7 +41,7 @@ Blocker[IO].use { blocker =>
   io.file
     .readAll[IO](Paths.get(file.toURI), blocker, 1024)
     .through(text.utf8Decode)
-    .through(targets(CatalogName.Simbad))
+    .through(siderealTargets(CatalogName.Simbad))
     .compile
     .lastOrError
     .unsafeRunSync()
@@ -56,6 +56,3 @@ Each example will query [Simbad](http://simbad.u-strasbg.fr/simbad/) using [sttp
 To stream parse xml we are using [fs2-data-xml](https://github.com/satabin/fs2-data), however
 the project is not yet available for both JVM/JS.
 
-This is temporarily solved internalizing the code for the specific module and cross compile it here.
-
-This won't not needed once https://github.com/satabin/fs2-data/issues/58 is solved

--- a/modules/benchmarks/src/main/scala/lucuma/catalog/GaiaBenchmark.scala
+++ b/modules/benchmarks/src/main/scala/lucuma/catalog/GaiaBenchmark.scala
@@ -4,11 +4,11 @@
 package lucuma.catalog
 
 import cats.effect._
+import cats.effect.unsafe.implicits.global
 import fs2._
+import org.openjdk.jmh.annotations._
 
 import java.util.concurrent.TimeUnit
-import org.openjdk.jmh.annotations._
-import cats.effect.unsafe.implicits.global
 
 @State(Scope.Thread)
 @Fork(1)

--- a/modules/benchmarks/src/main/scala/lucuma/catalog/SimbadBenchmark.scala
+++ b/modules/benchmarks/src/main/scala/lucuma/catalog/SimbadBenchmark.scala
@@ -4,11 +4,11 @@
 package lucuma.catalog
 
 import cats.effect._
+import cats.effect.unsafe.implicits.global
 import fs2._
+import org.openjdk.jmh.annotations._
 
 import java.util.concurrent.TimeUnit
-import org.openjdk.jmh.annotations._
-import cats.effect.unsafe.implicits.global
 
 @State(Scope.Thread)
 @Fork(1)

--- a/modules/catalog/src/main/scala/lucuma/catalog/CatalogSearch.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/CatalogSearch.scala
@@ -52,7 +52,7 @@ object CatalogSearch {
    */
   def siderealTargets[F[_]: RaiseThrowable](
     adapter: CatalogAdapter
-  ): Pipe[F, String, ValidatedNec[CatalogProblem, CatalogTargetResult]] =
+  ): Pipe[F, String, EitherNec[CatalogProblem, CatalogTargetResult]] =
     in =>
       in.flatMap(Stream.emits(_))
         .through(events[F, Char])

--- a/modules/catalog/src/main/scala/lucuma/catalog/Fields.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/Fields.scala
@@ -4,21 +4,20 @@
 package lucuma.catalog
 
 import cats._
-import cats.data.NonEmptyChain
-import cats.data.ValidatedNec
+import cats.data._
 import cats.implicits._
+import eu.timepit.refined._
 import eu.timepit.refined.cats._
-import eu.timepit.refined.cats.syntax._
 import eu.timepit.refined.types.string._
+import eu.timepit.refined.collection.NonEmpty
 import lucuma.catalog.CatalogProblem._
 
 /** Describes a field */
 case class FieldId(id: NonEmptyString, ucd: Option[Ucd])
 
 object FieldId {
-  def apply(id: String, ucd: Ucd): ValidatedNec[CatalogProblem, FieldId] =
-    NonEmptyString
-      .validateNec(id)
+  def apply(id: String, ucd: Ucd): EitherNec[CatalogProblem, FieldId] =
+    refineV[NonEmpty](id)
       .bimap(_ => NonEmptyChain.one(InvalidFieldId(id)).widen[CatalogProblem],
              FieldId(_, Some(ucd))
       )
@@ -27,7 +26,7 @@ object FieldId {
     apply(id, ucd).getOrElse(sys.error(s"Invalid field id $id"))
 
   def unsafeFrom(id: String, ucd: String): FieldId =
-    Ucd(ucd).andThen(apply(id, _)).getOrElse(sys.error(s"Invalid field id $id"))
+    Ucd(ucd).flatMap(apply(id, _)).getOrElse(sys.error(s"Invalid field id $id"))
 
   implicit val eqFieldId: Eq[FieldId] = Eq.by(x => (x.id, x.ucd))
 }

--- a/modules/catalog/src/main/scala/lucuma/catalog/Ucd.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/Ucd.scala
@@ -4,9 +4,7 @@
 package lucuma.catalog
 
 import cats._
-import cats.data.NonEmptyList
-import cats.data.Validated
-import cats.data.ValidatedNec
+import cats.data._
 import cats.implicits._
 import eu.timepit.refined._
 import eu.timepit.refined.cats._
@@ -25,18 +23,18 @@ final case class Ucd(tokens: NonEmptyList[NonEmptyString]) {
 }
 
 object Ucd {
-  def parseUcd(v: String): ValidatedNec[CatalogProblem, Ucd] =
+  def parseUcd(v: String): EitherNec[CatalogProblem, Ucd] =
     v.split(";").filter(_.nonEmpty).map(_.toLowerCase).toList match {
       case h :: tail =>
         (refineV[NonEmpty](h), tail.traverse(refineV[NonEmpty](_))) match {
           case (Right(h), Right(t)) =>
-            Ucd(NonEmptyList.of(h, t: _*)).validNec
-          case _                    => Validated.invalidNec(InvalidUcd(v))
+            Ucd(NonEmptyList.of(h, t: _*)).rightNec
+          case _                    => InvalidUcd(v).leftNec
         }
-      case _         => Validated.invalidNec(InvalidUcd(v))
+      case _         => InvalidUcd(v).leftNec
     }
 
-  def apply(ucd: String): ValidatedNec[CatalogProblem, Ucd] = parseUcd(ucd)
+  def apply(ucd: String): EitherNec[CatalogProblem, Ucd] = parseUcd(ucd)
 
   def apply(ucd: NonEmptyString): Ucd = Ucd(NonEmptyList.of(ucd))
 

--- a/modules/catalog/src/main/scala/lucuma/catalog/package.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/package.scala
@@ -3,6 +3,7 @@
 
 package lucuma
 
+import cats.syntax.all._
 import cats.data._
 import lucuma.catalog.CatalogProblem.FieldValueProblem
 
@@ -11,10 +12,10 @@ package object catalog {
   def parseDoubleValue(
     ucd: Option[Ucd],
     s:   String
-  ): ValidatedNec[CatalogProblem, Double] =
-    Validated
+  ): EitherNec[CatalogProblem, Double] =
+    Either
       .catchNonFatal(s.toDouble)
       .leftMap(_ => FieldValueProblem(ucd, s))
-      .toValidatedNec
+      .toEitherNec
 
 }

--- a/modules/tests/jvm/src/test/scala/lucuma/catalog/ParseSimbadFileSuite.scala
+++ b/modules/tests/jvm/src/test/scala/lucuma/catalog/ParseSimbadFileSuite.scala
@@ -3,7 +3,6 @@
 
 package lucuma.catalog
 
-import cats.data.Validated
 import cats.effect._
 import cats.implicits._
 import coulomb._
@@ -43,7 +42,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
         .compile
         .lastOrError
         .map {
-          case Validated.Valid(CatalogTargetResult(t, _)) =>
+          case Right(CatalogTargetResult(t, _)) =>
             // id and search name
             assertEquals(t.name, refineMV[NonEmpty]("Vega"))
             assertEquals(
@@ -111,7 +110,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
               Target.radialVelocity.getOption(t).flatten,
               RadialVelocity(-20.60.withUnit[KilometersPerSecond])
             )
-          case Validated.Invalid(_)                       => fail(s"VOTable xml $xmlFile cannot be parsed")
+          case Left(_)                          => fail(s"VOTable xml $xmlFile cannot be parsed")
         }
     }
   }
@@ -128,7 +127,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
         .compile
         .lastOrError
         .map {
-          case Validated.Valid(CatalogTargetResult(t, angularSize)) =>
+          case Right(CatalogTargetResult(t, angularSize)) =>
             // id and search name
             assertEquals(t.name, refineMV[NonEmpty]("2MFGC6625"))
             assertEquals(t.catalogInfo, CatalogInfo(CatalogName.Simbad, "2MFGC 6625", "EmG; I"))
@@ -204,7 +203,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
               angularSize,
               AngularSize(Angle.fromDMS(0, 0, 35, 400, 0), Angle.fromDMS(0, 0, 6, 359, 999)).some
             )
-          case Validated.Invalid(_)                                 => fail(s"VOTable xml $xmlFile cannot be parsed")
+          case Left(_)                                    => fail(s"VOTable xml $xmlFile cannot be parsed")
         }
     }
   }
@@ -220,7 +219,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
         .compile
         .lastOrError
         .map {
-          case Validated.Valid(CatalogTargetResult(t, _)) =>
+          case Right(CatalogTargetResult(t, _)) =>
             // id and search name
             assertEquals(t.name, refineMV[NonEmpty]("2SLAQ J000008.13+001634.6"))
             assertEquals(
@@ -328,7 +327,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
                 .withError(BigDecimal(0.068))
                 .some
             )
-          case Validated.Invalid(_)                       => fail(s"VOTable xml $xmlFile cannot be parsed")
+          case Left(_)                          => fail(s"VOTable xml $xmlFile cannot be parsed")
         }
     }
   }
@@ -345,13 +344,13 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
         .compile
         .lastOrError
         .map {
-          case Validated.Valid(CatalogTargetResult(t, _)) =>
+          case Right(CatalogTargetResult(t, _)) =>
             // parallax
             assertEquals(
               Target.parallax.getOption(t).flatten,
               Parallax.Zero.some
             )
-          case Validated.Invalid(_)                       => fail(s"VOTable xml $xmlFile cannot be parsed")
+          case Left(_)                          => fail(s"VOTable xml $xmlFile cannot be parsed")
         }
     }
   }
@@ -403,7 +402,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
         .compile
         .lastOrError
         .map {
-          case Validated.Valid(CatalogTargetResult(t, angularSize)) =>
+          case Right(CatalogTargetResult(t, angularSize)) =>
             // id and search name
             assertEquals(t.name, refineMV[NonEmpty]("NGC 2438"))
             assertEquals(t.catalogInfo, CatalogInfo(CatalogName.Simbad, "NGC  2438", "PN"))
@@ -420,7 +419,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
               angularSize,
               AngularSize(Angle.fromDMS(0, 1, 10, 380, 0), Angle.fromDMS(0, 1, 10, 380, 0)).some
             )
-          case Validated.Invalid(_)                                 => fail(s"VOTable xml $xmlFile cannot be parsed")
+          case Left(_)                                    => fail(s"VOTable xml $xmlFile cannot be parsed")
         }
     }
   }
@@ -438,7 +437,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
         .compile
         .lastOrError
         .map {
-          case Validated.Valid(CatalogTargetResult(t, _)) =>
+          case Right(CatalogTargetResult(t, _)) =>
             // proper motions
             assertEquals(
               Target.properMotionRA.getOption(t),
@@ -448,7 +447,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
               Target.properMotionDec.getOption(t),
               ProperMotion.Dec(286230.withUnit[MicroArcSecondPerYear]).some
             )
-          case Validated.Invalid(_)                       => fail(s"VOTable xml $xmlFile cannot be parsed")
+          case Left(_)                          => fail(s"VOTable xml $xmlFile cannot be parsed")
         }
     }
   }
@@ -466,7 +465,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
         .compile
         .lastOrError
         .map {
-          case Validated.Valid(CatalogTargetResult(t, _)) =>
+          case Right(CatalogTargetResult(t, _)) =>
             // id and search name
             assertEquals(t.name, refineMV[NonEmpty]("Vega"))
             assertEquals(
@@ -546,7 +545,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
               Target.radialVelocity.getOption(t).flatten,
               RadialVelocity(-20.60.withUnit[KilometersPerSecond])
             )
-          case Validated.Invalid(_)                       => fail(s"VOTable xml $xmlFile cannot be parsed")
+          case Left(_)                          => fail(s"VOTable xml $xmlFile cannot be parsed")
         }
     }
   }

--- a/modules/tests/shared/src/main/scala/lucuma/catalog/SimbadQuerySample.scala
+++ b/modules/tests/shared/src/main/scala/lucuma/catalog/SimbadQuerySample.scala
@@ -3,7 +3,7 @@
 
 package lucuma.catalog
 
-import cats.data.ValidatedNec
+import cats.data._
 import cats.effect.Concurrent
 import fs2._
 import org.http4s.Method._
@@ -14,7 +14,7 @@ trait SimbadQuerySample {
 
   def simbadQuery[F[_]: Concurrent](
     client: Client[F]
-  ): F[List[ValidatedNec[CatalogProblem, CatalogTargetResult]]] = {
+  ): F[List[EitherNec[CatalogProblem, CatalogTargetResult]]] = {
     val request = Request[F](GET, CatalogSearch.simbadSearchQuery(QueryByName("Vega")))
     client
       .stream(request)

--- a/modules/tests/shared/src/test/scala/lucuma/catalog/AdaptersSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/catalog/AdaptersSuite.scala
@@ -3,7 +3,6 @@
 
 package lucuma.catalog
 
-import cats.data.Validated
 import cats.effect._
 import cats.syntax.all._
 import coulomb._
@@ -41,7 +40,7 @@ class AdaptersSuite extends CatsEffectSuite with VoTableParser with VoTableSampl
       .compile
       .lastOrError
       .map {
-        case Validated.Valid(CatalogTargetResult(t, _)) =>
+        case Right(CatalogTargetResult(t, _)) =>
           assertEquals(t.name, refineMV[NonEmpty]("Gaia DR2 5500810326779190016"))
           assertEquals(t.tracking.epoch.some, Epoch.Julian.fromEpochYears(2015.5))
           assertEquals(
@@ -80,7 +79,7 @@ class AdaptersSuite extends CatsEffectSuite with VoTableParser with VoTableSampl
             Target.radialVelocity.getOption(t).flatten,
             RadialVelocity(20.30.withUnit[KilometersPerSecond])
           )
-        case Validated.Invalid(_)                       => fail("Gaia response could not be parsed")
+        case Left(_)                          => fail("Gaia response could not be parsed")
       }
   }
 }

--- a/modules/tests/shared/src/test/scala/lucuma/catalog/SimbadAdapterSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/catalog/SimbadAdapterSuite.scala
@@ -3,7 +3,7 @@
 
 package lucuma.catalog
 
-import cats.data.Validated
+import cats.syntax.all._
 import lucuma.core.enum.Band
 import munit.FunSuite
 
@@ -16,9 +16,7 @@ class SimbadAdapterSuite extends FunSuite {
     assertEquals(
       CatalogAdapter.Simbad
         .parseBrightnessValue(FieldId.unsafeFrom("FLUX_ERROR_r", magErrorUcd), "20.3051"),
-      Validated.validNec(
-        (FieldId.unsafeFrom("FLUX_ERROR_r", magErrorUcd), Band.SloanR, 20.3051)
-      )
+      (FieldId.unsafeFrom("FLUX_ERROR_r", magErrorUcd), Band.SloanR, 20.3051).rightNec
     )
 
     // FLUX_R maps to R
@@ -26,9 +24,7 @@ class SimbadAdapterSuite extends FunSuite {
       CatalogAdapter.Simbad.parseBrightnessValue(FieldId.unsafeFrom("FLUX_ERROR_R", magErrorUcd),
                                                  "20.3051"
       ),
-      Validated.validNec(
-        (FieldId.unsafeFrom("FLUX_ERROR_R", magErrorUcd), Band.R, 20.3051)
-      )
+      (FieldId.unsafeFrom("FLUX_ERROR_R", magErrorUcd), Band.R, 20.3051).rightNec
     )
   }
 }

--- a/modules/tests/shared/src/test/scala/lucuma/catalog/UcdSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/catalog/UcdSuite.scala
@@ -3,8 +3,8 @@
 
 package lucuma.catalog
 
-import _root_.cats.data.Validated
-import cats.data.NonEmptyList
+import cats.data._
+import cats.syntax.all._
 import cats.kernel.laws.discipline.EqTests
 import eu.timepit.refined._
 import eu.timepit.refined.collection._
@@ -23,21 +23,17 @@ class UcdSuite extends munit.FunSuite with DisciplineSuite {
     assert(Ucd.unsafeFromString("stat.error;phot.mag;em.opt.i").matches("em.opt.(\\w)".r))
   }
   test("parse single token ucds") {
-    assertEquals(Ucd.parseUcd("meta.code"),
-                 Validated.validNec(Ucd(refineMV[NonEmpty]("meta.code")))
-    )
+    assertEquals(Ucd.parseUcd("meta.code"), Ucd(refineMV[NonEmpty]("meta.code")).rightNec)
   }
   test("parse multi token ucds and preserve order") {
     assertEquals(
       Ucd.parseUcd("stat.error;phot.mag;em.opt.g"),
-      Validated.validNec(
-        Ucd(
-          NonEmptyList.of(refineMV[NonEmpty]("stat.error"),
-                          refineMV[NonEmpty]("phot.mag"),
-                          refineMV[NonEmpty]("em.opt.g")
-          )
+      Ucd(
+        NonEmptyList.of(refineMV[NonEmpty]("stat.error"),
+                        refineMV[NonEmpty]("phot.mag"),
+                        refineMV[NonEmpty]("em.opt.g")
         )
-      )
+      ).rightNec
     )
   }
   test("parse be case-insensitive, converting to lower case") {

--- a/modules/tests/shared/src/test/scala/lucuma/catalog/VoTableParserSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/catalog/VoTableParserSuite.scala
@@ -4,12 +4,10 @@
 package lucuma.catalog
 
 import cats.MonadError
-import cats.data.NonEmptyChain
-import cats.data.Validated
+import cats.syntax.all._
 import cats.effect._
 import fs2._
 import fs2.data.xml._
-import lucuma.catalog.CatalogProblem._
 import lucuma.catalog._
 import munit.CatsEffectSuite
 
@@ -24,208 +22,24 @@ class VoTableParserSuite extends CatsEffectSuite with VoTableParser with VoTable
       .through(referenceResolver[F]())
       .through(normalize[F])
 
-  test("be able to parse a field definition") {
-    val fieldXml =
-      <FIELD ID="gmag_err" datatype="double" name="gmag_err" ucd="stat.error;phot.mag;em.opt.g"/>
-    toStream[IO](fieldXml).through(fd).compile.lastOrError.map { r =>
-      assertEquals(
-        r,
-        Validated.validNec(
-          FieldId.unsafeFrom("gmag_err", Ucd.unsafeFromString("stat.error;phot.mag;em.opt.g"))
-        )
-      )
-    }
-  }
-  test("ignore empty fields") {
-    // Empty field
-    toStream[IO](<FIELD/>)
-      .through(fd)
-      .compile
-      .lastOrError
-      .map(
-        assertEquals(
-          _,
-          Validated.invalid(NonEmptyChain(MissingXmlAttribute("ID"), MissingXmlAttribute("ucd")))
-        )
-      )
-  }
-  test("non field xml") {
-    // non field xml
-    toStream[IO](<TAG/>)
-      .through(fd)
-      .compile
-      .lastOrError
-      .map(assertEquals(_, Validated.invalidNec(UnknownXmlTag("TAG"))))
-  }
-  test("missing attributes") {
-    // missing attributes
-    toStream[IO](<FIELD ID="abc"/>)
-      .through(fd)
-      .compile
-      .lastOrError
-      .map(
-        assertEquals(_, Validated.invalid(NonEmptyChain(MissingXmlAttribute("ucd"))))
-      )
-  }
-  test("swap in name for ID if missing in a field definition") {
-    val fieldXml = <FIELD datatype="double" name="ref_epoch" ucd="meta.ref;time.epoch" unit="yr"/>
-    toStream[IO](fieldXml)
-      .through(fd)
-      .compile
-      .lastOrError
-      .map(
-        assertEquals(
-          _,
-          Validated.validNec(
-            FieldId.unsafeFrom("ref_epoch", Ucd.unsafeFromString("meta.ref;time.epoch"))
-          )
-        )
-      )
-  }
-  test("parse a list of fields") {
-    val result =
-      List(
-        FieldId.unsafeFrom("gmag_err", Ucd.unsafeFromString("stat.error;phot.mag;em.opt.g")),
-        FieldId.unsafeFrom("rmag_err", Ucd.unsafeFromString("stat.error;phot.mag;em.opt.r")),
-        FieldId.unsafeFrom("flags1", Ucd.unsafeFromString("meta.code")),
-        FieldId.unsafeFrom("ppmxl", Ucd.unsafeFromString("meta.id;meta.main"))
-      )
-
-    toStream[IO](fieldsNode)
-      .through(fds)
-      .compile
-      .lastOrError
-      .map(assertEquals(_, result.map(Validated.validNec)))
-  }
-  test("parse a data row with a list of fields") {
-    val fields = toStream[IO](fieldsNode).through(fds)
-
-    val result = TableRow(
-      List(
-        TableRowItem(FieldId.unsafeFrom("gmag_err", "stat.error;phot.mag;em.opt.g"), "0.0960165"),
-        TableRowItem(FieldId.unsafeFrom("rmag_err", "stat.error;phot.mag;em.opt.r"), "0.0503736"),
-        TableRowItem(FieldId.unsafeFrom("flags1", "meta.code"), "268435728"),
-        TableRowItem(FieldId.unsafeFrom("ppmxl", "meta.id;meta.main"), "-2140405448")
-      )
-    )
-    fields
-      .flatMap { fields =>
-        val fl = fields.collect { case Validated.Valid(f) => f }
-        toStream[IO](tableRow).through(tr(fl))
-      }
-      .compile
-      .lastOrError
-      .map(assertEquals(_, Validated.validNec(result)))
-  }
-  test("detect missing fields") {
-    val fields = toStream[IO](fieldsNode).through(fds)
-
-    fields
-      .flatMap { fields =>
-        val fl = fields.collect { case Validated.Valid(f) => f }
-        toStream[IO](tableRowMissing).through(tr(fl))
-      }
-      .compile
-      .lastOrError
-      .map(
-        assertEquals(_,
-                     Validated.invalidNec[CatalogProblem, TableRow](
-                       MissingValue(FieldId.unsafeFrom("ppmxl", "meta.id;meta.main"))
-                     )
-        )
-      )
-  }
-  test("detect extra fields") {
-    val fields = toStream[IO](fieldsNode).through(fds)
-
-    fields
-      .flatMap { fields =>
-        val fl = fields.collect { case Validated.Valid(f) => f }
-        toStream[IO](tableRowExtra).through(tr(fl))
-      }
-      .compile
-      .lastOrError
-      .map(assertEquals(_, Validated.invalidNec[CatalogProblem, TableRow](ExtraRow)))
-  }
-  test("parse a list of rows with a list of fields") {
-    val fields = toStream[IO](fieldsNode).through(fds)
-
-    val result = List(
-      TableRow(
-        List(
-          TableRowItem(FieldId.unsafeFrom("gmag_err", "stat.error;phot.mag;em.opt.g"), "0.0960165"),
-          TableRowItem(FieldId.unsafeFrom("rmag_err", "stat.error;phot.mag;em.opt.r"), "0.0503736"),
-          TableRowItem(FieldId.unsafeFrom("flags1", "meta.code"), "268435728"),
-          TableRowItem(FieldId.unsafeFrom("ppmxl", "meta.id;meta.main"), "-2140405448")
-        )
-      ),
-      TableRow(
-        List(
-          TableRowItem(FieldId.unsafeFrom("gmag_err", "stat.error;phot.mag;em.opt.g"), "0.51784"),
-          TableRowItem(FieldId.unsafeFrom("rmag_err", "stat.error;phot.mag;em.opt.r"), "0.252201"),
-          TableRowItem(FieldId.unsafeFrom("flags1", "meta.code"), "536871168"),
-          TableRowItem(FieldId.unsafeFrom("ppmxl", "meta.id;meta.main"), "-2140404569")
-        )
-      )
-    )
-
-    fields
-      .flatMap { fields =>
-        val fl = fields.collect { case Validated.Valid(f) => f }
-        toStream[IO](dataNode).through(trs(fl))
-      }
-      .compile
-      .toList
-      .map(assertEquals(_, result.map(Validated.validNec)))
-  }
-  test("parse a list of rows with a list of fields and one missing row") {
-    val fields = toStream[IO](fieldsNode).through(fds)
-
-    val result = List(
-      Validated.invalidNec(MissingValue((FieldId.unsafeFrom("ppmxl", "meta.id;meta.main")))),
-      Validated.validNec(
-        TableRow(
-          List(
-            TableRowItem(FieldId.unsafeFrom("gmag_err", "stat.error;phot.mag;em.opt.g"), "0.51784"),
-            TableRowItem(FieldId.unsafeFrom("rmag_err", "stat.error;phot.mag;em.opt.r"),
-                         "0.252201"
-            ),
-            TableRowItem(FieldId.unsafeFrom("flags1", "meta.code"), "536871168"),
-            TableRowItem(FieldId.unsafeFrom("ppmxl", "meta.id;meta.main"), "-2140404569")
-          )
-        )
-      )
-    )
-
-    fields
-      .flatMap { fields =>
-        val fl = fields.collect { case Validated.Valid(f) => f }
-        toStream[IO](dataNodeMissing).through(trs(fl))
-      }
-      .compile
-      .toList
-      .map(assertEquals(_, result))
-  }
   test("parse a list of rows") {
     val result = List(
-      Validated.validNec(
-        TableRow(
-          List(
-            TableRowItem(FieldId.unsafeFrom("flags1", "meta.code"), "268435728"),
-            TableRowItem(FieldId.unsafeFrom("umag", "phot.mag;em.opt.u"), "23.0888"),
-            TableRowItem(FieldId.unsafeFrom("flags2", "meta.code"), "8208"),
-            TableRowItem(FieldId.unsafeFrom("imag", "phot.mag;em.opt.i"), "20.3051"),
-            TableRowItem(FieldId.unsafeFrom("decj2000", "pos.eq.dec;meta.main"), "0.209323681906"),
-            TableRowItem(FieldId.unsafeFrom("raj2000", "pos.eq.ra;meta.main"), "359.745951955"),
-            TableRowItem(FieldId.unsafeFrom("rmag", "phot.mag;em.opt.r"), "20.88"),
-            TableRowItem(FieldId.unsafeFrom("objid", "meta.id;meta.main"), "-2140405448"),
-            TableRowItem(FieldId.unsafeFrom("gmag", "phot.mag;em.opt.g"), "22.082"),
-            TableRowItem(FieldId.unsafeFrom("zmag", "phot.mag;em.opt.z"), "19.8812"),
-            TableRowItem(FieldId.unsafeFrom("type", "meta.code"), "3"),
-            TableRowItem(FieldId.unsafeFrom("ppmxl", "meta.id;meta.main"), "-2140405448")
-          )
+      TableRow(
+        List(
+          TableRowItem(FieldId.unsafeFrom("flags1", "meta.code"), "268435728"),
+          TableRowItem(FieldId.unsafeFrom("umag", "phot.mag;em.opt.u"), "23.0888"),
+          TableRowItem(FieldId.unsafeFrom("flags2", "meta.code"), "8208"),
+          TableRowItem(FieldId.unsafeFrom("imag", "phot.mag;em.opt.i"), "20.3051"),
+          TableRowItem(FieldId.unsafeFrom("decj2000", "pos.eq.dec;meta.main"), "0.209323681906"),
+          TableRowItem(FieldId.unsafeFrom("raj2000", "pos.eq.ra;meta.main"), "359.745951955"),
+          TableRowItem(FieldId.unsafeFrom("rmag", "phot.mag;em.opt.r"), "20.88"),
+          TableRowItem(FieldId.unsafeFrom("objid", "meta.id;meta.main"), "-2140405448"),
+          TableRowItem(FieldId.unsafeFrom("gmag", "phot.mag;em.opt.g"), "22.082"),
+          TableRowItem(FieldId.unsafeFrom("zmag", "phot.mag;em.opt.z"), "19.8812"),
+          TableRowItem(FieldId.unsafeFrom("type", "meta.code"), "3"),
+          TableRowItem(FieldId.unsafeFrom("ppmxl", "meta.id;meta.main"), "-2140405448")
         )
-      )
+      ).rightNec
     )
 
     toStream[IO](targets)


### PR DESCRIPTION
This was discussed long ago, `Validated` can be replaced by `EitherNec` thus reducing a bit the cognitive load of this module. It breaks the api but we have done that anyway for the next release