### PR TITLE
Use Node.js built-in fetch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,6 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
   .in(file("modules/tests"))
   .enablePlugins(NoPublishPlugin)
-  .jsEnablePlugins(ScalaJSBundlerPlugin)
   .dependsOn(catalog, testkit, ags)
   .settings(
     name := "lucuma-catalog-tests",
@@ -92,10 +91,13 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
   .jsSettings(
     scalaJSUseMainModuleInitializer := true,
     scalacOptions ~= (_.filterNot(Set("-Wdead-code"))),
-    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
     libraryDependencies ++= Seq(
       "org.http4s" %%% "http4s-dom" % http4sDomVersion
-    )
+    ),
+    jsEnv                           := {
+      import org.scalajs.jsenv.nodejs.NodeJSEnv
+      new NodeJSEnv(NodeJSEnv.Config().withArgs(List("--experimental-fetch")))
+    }
   )
   .jvmSettings(
     libraryDependencies ++= Seq(

--- a/modules/tests/js/package.json
+++ b/modules/tests/js/package.json
@@ -1,7 +1,0 @@
-{
-  "devDependencies": {
-    "abortcontroller-polyfill": "^1.5.0",
-    "fetch-headers": "^2.0.0",
-    "node-fetch": "^2.6.1"
-  }
-}

--- a/modules/tests/js/src/main/scala/lucuma/catalog/SimbadQueryApp.scala
+++ b/modules/tests/js/src/main/scala/lucuma/catalog/SimbadQueryApp.scala
@@ -6,42 +6,15 @@ package lucuma.catalog
 import cats.effect._
 import org.http4s.dom.FetchClientBuilder
 
-import scala.annotation.nowarn
-import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
-@nowarn
 @JSExportTopLevel("main")
 object SimbadQueryApp extends IOApp.Simple with SimbadQuerySample {
-  @js.native
-  @JSImport("node-fetch", JSImport.Namespace)
-  val nodeFetch: js.Object = js.native
 
-  @js.native
-  @JSImport("node-fetch", "Request")
-  val Request: js.Object = js.native
-
-  @js.native
-  @JSImport("abortcontroller-polyfill/dist/cjs-ponyfill", "AbortController")
-  val AbortController: js.Object = js.native
-
-  @js.native
-  @JSImport("fetch-headers", JSImport.Namespace)
-  val fetchHeaders: js.Object = js.native
-
-  def run = {
-
-    // This is required to import these modules in node
-    // It shouldn't be necessary in a browser
-    val g = scalajs.js.Dynamic.global.globalThis
-    g.fetch = nodeFetch
-    g.AbortController = AbortController
-    g.Headers = fetchHeaders
-    g.Request = Request
-
+  def run =
     FetchClientBuilder[IO].resource
       .use(simbadQuery[IO])
       .flatMap(x => IO.println(pprint.apply(x)))
       .void
-  }
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,6 @@ resolvers += Resolver.sonatypeRepo("public")
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 val sbtLucumaVersion = "0.8.4"
-addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib"         % sbtLucumaVersion)
-addSbtPlugin("edu.gemini"         % "sbt-lucuma-sjs-bundler" % sbtLucumaVersion)
-addSbtPlugin("com.timushev.sbt"   % "sbt-updates"            % "0.6.3")
-addSbtPlugin("ch.epfl.scala"      % "sbt-scalajs-bundler"    % "0.20.0")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"                % "0.4.3")
+addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib" % sbtLucumaVersion)
+addSbtPlugin("com.timushev.sbt"   % "sbt-updates"    % "0.6.3")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"        % "0.4.3")


### PR DESCRIPTION
Node.js now includes experimental support for `fetch` itself so the npm package is no longer necessary.