### PR TITLE
More efficient

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val munitVersion               = "0.7.29"
 lazy val munitDisciplineVersion     = "1.0.9"
 lazy val munitCatsEffectVersion     = "1.0.7"
 lazy val betterMonadicForVersion    = "0.3.1"
-lazy val refinedVersion             = "0.9.29"
+lazy val refinedVersion             = "0.10.0"
 lazy val catsScalacheckVersion      = "0.3.1"
 lazy val scalaXmlVersion            = "2.1.0"
 lazy val http4sVersion              = "0.23.13"
@@ -18,9 +18,8 @@ lazy val http4sJdkHttpClientVersion = "0.7.0"
 lazy val http4sDomVersion           = "0.2.3"
 
 Global / onChangedBuildSource   := ReloadOnSourceChanges
-Global / scalacOptions += "-Ymacro-annotations"
 
-ThisBuild / tlBaseVersion       := "0.18"
+ThisBuild / tlBaseVersion       := "0.19"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val root = tlCrossRootProject.aggregate(catalog, ags, testkit, tests)
@@ -64,10 +63,11 @@ lazy val testkit = crossProject(JVMPlatform, JSPlatform)
   .settings(
     name := "lucuma-catalog-testkit",
     libraryDependencies ++= Seq(
-      "org.typelevel"     %%% "cats-testkit"        % catsVersion,
-      "edu.gemini"        %%% "lucuma-core-testkit" % lucumaCoreVersion,
-      "eu.timepit"        %%% "refined-scalacheck"  % refinedVersion,
-      "io.chrisdavenport" %%% "cats-scalacheck"     % catsScalacheckVersion
+      "org.typelevel"          %%% "cats-testkit"        % catsVersion,
+      "edu.gemini"             %%% "lucuma-core-testkit" % lucumaCoreVersion,
+      "eu.timepit"             %%% "refined-scalacheck"  % refinedVersion,
+      "org.scala-lang.modules" %%% "scala-xml"           % scalaXmlVersion,
+      "io.chrisdavenport"      %%% "cats-scalacheck"     % catsScalacheckVersion
     )
   )
 
@@ -79,13 +79,12 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
   .settings(
     name := "lucuma-catalog-tests",
     libraryDependencies ++= Seq(
-      "org.typelevel"          %%% "cats-effect"         % catsEffectVersion      % Test,
-      "org.scalameta"          %%% "munit"               % munitVersion           % Test,
-      "org.typelevel"          %%% "discipline-munit"    % munitDisciplineVersion % Test,
-      "org.typelevel"          %%% "munit-cats-effect-3" % munitCatsEffectVersion % Test,
-      "org.scala-lang.modules" %%% "scala-xml"           % scalaXmlVersion        % Test,
-      "org.http4s"             %%% "http4s-core"         % http4sVersion,
-      "com.lihaoyi"            %%% "pprint"              % pprintVersion
+      "org.typelevel" %%% "cats-effect"         % catsEffectVersion      % Test,
+      "org.scalameta" %%% "munit"               % munitVersion           % Test,
+      "org.typelevel" %%% "discipline-munit"    % munitDisciplineVersion % Test,
+      "org.typelevel" %%% "munit-cats-effect-3" % munitCatsEffectVersion % Test,
+      "org.http4s"    %%% "http4s-core"         % http4sVersion,
+      "com.lihaoyi"   %%% "pprint"              % pprintVersion
     )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val http4sVersion              = "0.23.13"
 lazy val http4sJdkHttpClientVersion = "0.7.0"
 lazy val http4sDomVersion           = "0.2.3"
 
-Global / onChangedBuildSource   := ReloadOnSourceChanges
+Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / tlBaseVersion       := "0.19"
 ThisBuild / tlCiReleaseBranches := Seq("master")

--- a/modules/ags/src/main/scala/lucuma/ags/Ags.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/Ags.scala
@@ -81,7 +81,7 @@ object Ags {
       .map { g =>
         fastestGuideSpeed(constraints, wavelength, g)
           .map(usable)
-          .getOrElse(NoGuideStarForProbe(guideProbe))
+          .getOrElse(NoGuideStarForProbe(guideProbe, guideStar))
       }
       .getOrElse(NoMagnitudeForBand(guideProbe, guideStar))
   }
@@ -95,11 +95,11 @@ object Ags {
     baseCoordinates: Coordinates,
     position:        AgsPosition,
     params:          AgsParams
-  ): Pipe[F, GuideStarCandidate, (GuideStarCandidate, AgsAnalysis)] =
+  ): Pipe[F, GuideStarCandidate, AgsAnalysis] =
     in =>
       in.map { gsc =>
         val offset = baseCoordinates.diff(gsc.tracking.baseCoordinates).offset
-        gsc -> runAnalysis(constraints, wavelength, offset, position, params, gsc)
+        runAnalysis(constraints, wavelength, offset, position, params, gsc)
       }
 
   /**
@@ -112,10 +112,10 @@ object Ags {
     position:        AgsPosition,
     params:          AgsParams,
     candidates:      List[GuideStarCandidate]
-  ): List[(GuideStarCandidate, AgsAnalysis)] =
+  ): List[AgsAnalysis] =
     candidates.map { gsc =>
       val offset = baseCoordinates.diff(gsc.tracking.baseCoordinates).offset
-      gsc -> runAnalysis(constraints, wavelength, offset, position, params, gsc)
+      runAnalysis(constraints, wavelength, offset, position, params, gsc)
     }
 
   /**

--- a/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
@@ -5,10 +5,10 @@ package lucuma.ags
 
 import cats.Order
 import cats.syntax.all._
+import lucuma.catalog.BandsList
 import lucuma.core.enums.Band
 import lucuma.core.enums.GuideSpeed
 import lucuma.core.geom.Area
-import lucuma.catalog.BandsList
 
 sealed trait AgsAnalysis {
   def quality: AgsGuideQuality = AgsGuideQuality.Unusable

--- a/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
@@ -8,20 +8,23 @@ import cats.syntax.all._
 import lucuma.core.enums.Band
 import lucuma.core.enums.GuideSpeed
 import lucuma.core.geom.Area
+import lucuma.catalog.BandsList
 
 sealed trait AgsAnalysis {
   def quality: AgsGuideQuality = AgsGuideQuality.Unusable
   def isUsable: Boolean        = quality =!= AgsGuideQuality.Unusable
+  def target: GuideStarCandidate
   def message(withProbe: Boolean): String
 }
 
 object AgsAnalysis {
 
-  case object NotAnalized extends AgsAnalysis {
+  final case class NotAnalized(target: GuideStarCandidate) extends AgsAnalysis {
     override def message(withProbe: Boolean): String = "Not analyzed yet"
   }
 
-  final case class NoGuideStarForProbe(guideProbe: GuideProbe) extends AgsAnalysis {
+  final case class NoGuideStarForProbe(guideProbe: GuideProbe, target: GuideStarCandidate)
+      extends AgsAnalysis {
     override def message(withProbe: Boolean): String = {
       val p = if (withProbe) s"$guideProbe " else ""
       s"No ${p}guide star selected."
@@ -66,7 +69,7 @@ object AgsAnalysis {
 
   final case class NoMagnitudeForBand(guideProbe: GuideProbe, target: GuideStarCandidate)
       extends AgsAnalysis {
-    private val probeBands: List[Band]               = Nil // guideProbe.getBands
+    private val probeBands: List[Band]               = BandsList.GaiaBandsList.bands
     override def message(withProbe: Boolean): String = {
       val p = if (withProbe) s"${guideProbe} g" else "G"
       if (probeBands.length == 1) {

--- a/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
@@ -62,11 +62,6 @@ object AgsAnalysis {
     }
   }
 
-  object NotReachable {
-    implicit val order: Order[NotReachable] =
-      Order.allEqual
-  }
-
   final case class NoMagnitudeForBand(guideProbe: GuideProbe, target: GuideStarCandidate)
       extends AgsAnalysis {
     private val probeBands: List[Band]               = BandsList.GaiaBandsList.bands
@@ -79,11 +74,6 @@ object AgsAnalysis {
       }
     }
     override val quality: AgsGuideQuality            = AgsGuideQuality.PossiblyUnusable
-  }
-
-  object NoMagnitudeForBand {
-    implicit val order: Order[NoMagnitudeForBand] =
-      Order.allEqual
   }
 
   final case class Usable(
@@ -106,18 +96,18 @@ object AgsAnalysis {
   }
 
   object Usable {
-    implicit val order: Order[Usable] =
-      Order.by(u => (u.guideSpeed, u.quality, u.vignettingArea))
+    val rankingOrder: Order[Usable] =
+      Order.by(u => (u.guideSpeed, u.quality, u.vignettingArea, u.target.id))
   }
 
-  implicit val order: Order[AgsAnalysis] =
+  val rankingOrder: Order[AgsAnalysis] =
     Order.from {
-      case (a: Usable, b: Usable) => Usable.order.compare(a, b)
+      case (a: Usable, b: Usable) => Usable.rankingOrder.compare(a, b)
       case (_: Usable, _)         => Int.MinValue
       case (_, _: Usable)         => Int.MaxValue
       case _                      => Int.MinValue
     }
 
-  implicit val ordering: Ordering[AgsAnalysis] = order.toOrdering
+  val rankingOrdering: Ordering[AgsAnalysis] = rankingOrder.toOrdering
 
 }

--- a/modules/testkit/src/main/scala/lucuma/ags/arb/ArbGuideStarCandidate.scala
+++ b/modules/testkit/src/main/scala/lucuma/ags/arb/ArbGuideStarCandidate.scala
@@ -3,8 +3,6 @@
 
 package lucuma.ags.arb
 
-import eu.timepit.refined.scalacheck.string._
-import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.ags.GuideStarCandidate
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.arb.ArbSiderealTracking
@@ -18,15 +16,15 @@ trait ArbGuideStarCandidate {
   implicit val arbGuideStarCandidate: Arbitrary[GuideStarCandidate] =
     Arbitrary {
       for {
-        n <- arbitrary[NonEmptyString]
+        n <- arbitrary[Long]
         t <- arbitrary[SiderealTracking]
         g <- arbitrary[Option[BigDecimal]]
       } yield GuideStarCandidate(n, t, g)
     }
 
   implicit val cogGuideStarCandidate: Cogen[GuideStarCandidate] =
-    Cogen[(String, SiderealTracking, Option[BigDecimal])].contramap(r =>
-      (r.name.value, r.tracking, r.gBrightness)
+    Cogen[(Long, SiderealTracking, Option[BigDecimal])].contramap(r =>
+      (r.id, r.tracking, r.gBrightness)
     )
 }
 

--- a/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
@@ -12,7 +12,6 @@ import fs2.text
 import lucuma.ags._
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.GmosNorthFpu
-import lucuma.core.enums.GuideSpeed
 import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.PortDisposition
 import lucuma.core.enums.SkyBackground
@@ -74,12 +73,12 @@ object AgsSelectionSampleApp extends IOApp.Simple with AgsSelectionSample {
     JdkHttpClient
       .simple[IO]
       .use(
-        gaiaQuery[IO](_, gaiaBrightnessConstraints(constraints, GuideSpeed.Fast, wavelength))
+        gaiaQuery[IO](_, widestConstraints)
           .map(GuideStarCandidate.siderealTarget.get)
           .through(
             Ags.agsAnalysisStream[IO](
               constraints,
-              Wavelength.fromNanometers(700).get,
+              wavelength,
               coords,
               AgsPosition(Angle.Angle0, Offset.Zero),
               AgsParams.GmosAgsParams(
@@ -91,6 +90,7 @@ object AgsSelectionSampleApp extends IOApp.Simple with AgsSelectionSample {
           .compile
           .toList
       )
+      .flatTap(x => IO.println(x.length))
       .flatMap(x => x.traverse(u => IO(pprint.pprintln(u))))
       .void
 }

--- a/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
@@ -91,6 +91,6 @@ object AgsSelectionSampleApp extends IOApp.Simple with AgsSelectionSample {
           .toList
       )
       .flatTap(x => IO.println(x.length))
-      .flatMap(x => x.traverse(u => IO(pprint.pprintln(u))))
+      // .flatMap(x => x.traverse(u => IO(pprint.pprintln(u))))
       .void
 }


### PR DESCRIPTION
This  PR introduces a few changes to make storing targets more efficient:
* Store  ags analysis and target together
* Use gaia's source id (long) instead of the name (String)

It also updates refined