### PR TITLE
Small changes in object info string building

### DIFF
--- a/modules/catalog/src/main/scala/lucuma/catalog/votable/VoTableParser.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/votable/VoTableParser.scala
@@ -227,10 +227,11 @@ trait VoTableParser {
 
     def parseObjType: Option[NonEmptyString] =
       refineV[NonEmpty](
-        List(entries.get(adapter.oTypeField),
-             entries.get(adapter.spTypeField),
-             entries.get(adapter.morphTypeField)
-        ).flatten.mkString("; ")
+        List(
+          entries.get(adapter.oTypeField),
+          entries.get(adapter.morphTypeField),
+          entries.get(adapter.spTypeField)
+        ).flatten.mkString(", ")
       ).toOption
 
     def parseCatalogInfo: EitherNec[CatalogProblem, Option[CatalogInfo]] =

--- a/modules/tests/jvm/src/test/scala/lucuma/catalog/ParseSimbadFileSuite.scala
+++ b/modules/tests/jvm/src/test/scala/lucuma/catalog/ParseSimbadFileSuite.scala
@@ -56,7 +56,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
             assertEquals(t.name, "Vega".refined[NonEmpty])
             assertEquals(
               t.catalogInfo,
-              CatalogInfo(CatalogName.Simbad, "* alf Lyr", "PulsV*delSct; A0Va")
+              CatalogInfo(CatalogName.Simbad, "* alf Lyr", "PulsV*delSct, A0Va")
             )
             // base coordinates
             assertEquals(
@@ -139,7 +139,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
           case Right(CatalogTargetResult(t, angularSize)) =>
             // id and search name
             assertEquals(t.name, "2MFGC6625".refined[NonEmpty])
-            assertEquals(t.catalogInfo, CatalogInfo(CatalogName.Simbad, "2MFGC 6625", "EmG; I"))
+            assertEquals(t.catalogInfo, CatalogInfo(CatalogName.Simbad, "2MFGC 6625", "EmG, I"))
             // base coordinates
             assertEquals(
               Target.baseRA.getOption(t),
@@ -493,7 +493,7 @@ class ParseSimbadFileSuite extends CatsEffectSuite with VoTableParser {
             assertEquals(t.name, "Vega".refined[NonEmpty])
             assertEquals(
               t.catalogInfo,
-              CatalogInfo(CatalogName.Simbad, "* alf Lyr", "PulsV*delSct; A0Va")
+              CatalogInfo(CatalogName.Simbad, "* alf Lyr", "PulsV*delSct, A0Va")
             )
             // base coordinates
             assertEquals(


### PR DESCRIPTION
Build the string for the catalog info with `,` instead of `;` and with morphology before spectral profile.