### PR TITLE
Remove unusable targets from the results

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val kittensVersion             = "3.0.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion       := "0.40"
+ThisBuild / tlBaseVersion       := "0.41"
 ThisBuild / tlCiReleaseBranches := Seq("master", "scala3")
 
 ThisBuild / scalaVersion       := "3.3.0"

--- a/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
@@ -165,17 +165,12 @@ object AgsAnalysis {
         results
           .groupBy(_.target.id)
           .flatMap { (_, analyses) =>
-            val usable = analyses.collect {
-              case r if r.isUsable => r
-            }
+            val usable = analyses.collect { case u: Usable => u }
             // If there is at least a single usable result, we can sort by vignetting
             // and discard the non usable results
             if (usable.nonEmpty) {
               List(
                 usable
-                  .collect { case u: Usable =>
-                    u
-                  }
                   .reduce((a, b) => a.copy(vignetting = a.vignetting.concatNel(b.vignetting)))
                   .sortedVignetting
               )

--- a/modules/ags/src/main/scala/lucuma/ags/package.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/package.scala
@@ -132,7 +132,9 @@ def gaiaBrightnessConstraints(
   )
 
 private val UnconstrainedAngles =
-  (0 until 360 by 10).map(a => Angle.fromDoubleDegrees(a.toDouble)).toList
+  NonEmptyList.fromListUnsafe(
+    (0 until 360 by 10).map(a => Angle.fromDoubleDegrees(a.toDouble)).toList
+  )
 
 extension (posAngleConstraint: PosAngleConstraint)
   def anglesToTestAt(
@@ -145,4 +147,4 @@ extension (posAngleConstraint: PosAngleConstraint)
     case PosAngleConstraint.ParallacticOverride(a) => NonEmptyList.of(a).some
     case PosAngleConstraint.AverageParallactic     =>
       averageParallacticAngle(site, tracking, vizTime).map(a => NonEmptyList.of(a, a.flip))
-    case PosAngleConstraint.Unbounded              => NonEmptyList.fromList(UnconstrainedAngles)
+    case PosAngleConstraint.Unbounded              => UnconstrainedAngles.some

--- a/modules/ags/src/main/scala/lucuma/ags/package.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/package.scala
@@ -132,7 +132,7 @@ def gaiaBrightnessConstraints(
   )
 
 private val UnconstrainedAngles =
-  NonEmptyList.fromListUnsafe(
+  NonEmptyList.fromList(
     (0 until 360 by 10).map(a => Angle.fromDoubleDegrees(a.toDouble)).toList
   )
 
@@ -147,4 +147,4 @@ extension (posAngleConstraint: PosAngleConstraint)
     case PosAngleConstraint.ParallacticOverride(a) => NonEmptyList.of(a).some
     case PosAngleConstraint.AverageParallactic     =>
       averageParallacticAngle(site, tracking, vizTime).map(a => NonEmptyList.of(a, a.flip))
-    case PosAngleConstraint.Unbounded              => UnconstrainedAngles.some
+    case PosAngleConstraint.Unbounded              => UnconstrainedAngles

--- a/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionStreamApp.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionStreamApp.scala
@@ -9,34 +9,14 @@ import cats.effect.IOApp
 import cats.syntax.all.*
 import fs2.*
 import lucuma.ags.*
-import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.GmosNorthFpu
-import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.PortDisposition
-import lucuma.core.enums.SkyBackground
-import lucuma.core.enums.WaterVapor
 import lucuma.core.math.Angle
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Offset
-import lucuma.core.math.Wavelength
-import lucuma.core.model.ConstraintSet
-import lucuma.core.model.ElevationRange
-import lucuma.core.model.ElevationRange.AirMass
-import lucuma.core.model.ElevationRange.AirMass.DecimalValue
 import org.http4s.jdkhttpclient.JdkHttpClient
 
 object AgsSelectionSampleStreamApp extends IOApp.Simple with AgsSelectionSample {
-  val constraints = ConstraintSet(
-    ImageQuality.PointOne,
-    CloudExtinction.PointOne,
-    SkyBackground.Dark,
-    WaterVapor.Wet,
-    AirMass.fromDecimalValues.get(DecimalValue.unsafeFrom(BigDecimal(1.0)),
-                                  DecimalValue.unsafeFrom(BigDecimal(1.75))
-    )
-  )
-
-  val wavelength = Wavelength.fromIntNanometers(520).get
 
   def run =
     JdkHttpClient

--- a/modules/tests/shared/src/test/scala/lucuma/ags/AgsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/ags/AgsSuite.scala
@@ -5,6 +5,7 @@ package lucuma.ags
 
 import cats.data.NonEmptyList
 import cats.syntax.all.*
+import lucuma.ags.AgsAnalysis.NoMagnitudeForBand
 import lucuma.ags.AgsAnalysis.Usable
 import lucuma.core.enums.*
 import lucuma.core.geom.Area
@@ -30,7 +31,7 @@ class AgsSuite extends munit.FunSuite {
     val u1 = Usable(
       GuideProbe.OIWFS,
       gs1,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
@@ -39,7 +40,7 @@ class AgsSuite extends munit.FunSuite {
     val u2 = Usable(
       GuideProbe.OIWFS,
       gs1,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(1).get
@@ -48,7 +49,7 @@ class AgsSuite extends munit.FunSuite {
     val u3 = Usable(
       GuideProbe.OIWFS,
       gs2,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
@@ -57,7 +58,7 @@ class AgsSuite extends munit.FunSuite {
     val u4 = Usable(
       GuideProbe.OIWFS,
       gs2,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(2).get
@@ -67,7 +68,7 @@ class AgsSuite extends munit.FunSuite {
     val u12 = Usable(
       GuideProbe.OIWFS,
       gs1,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle0, Offset.Zero)   -> Area.fromMicroarcsecondsSquared.getOption(0).get,
@@ -80,7 +81,7 @@ class AgsSuite extends munit.FunSuite {
     val u22 = Usable(
       GuideProbe.OIWFS,
       gs2,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle0, Offset.Zero)   -> Area.fromMicroarcsecondsSquared.getOption(9).get,
@@ -104,7 +105,7 @@ class AgsSuite extends munit.FunSuite {
     val u1 = Usable(
       GuideProbe.OIWFS,
       gs1,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle180, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
@@ -113,7 +114,7 @@ class AgsSuite extends munit.FunSuite {
     val u2 = Usable(
       GuideProbe.OIWFS,
       gs2,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
@@ -129,7 +130,7 @@ class AgsSuite extends munit.FunSuite {
     val u1        = Usable(
       GuideProbe.OIWFS,
       gs1,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
@@ -138,13 +139,33 @@ class AgsSuite extends munit.FunSuite {
     val u2        = Usable(
       GuideProbe.OIWFS,
       gs1,
-      GuideSpeed.Fast.some,
+      GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
         AgsPosition(Angle.Angle180, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(1).get
       )
     )
-    assertEquals(1, List(u1, u2).sortPositions(positions).length)
+    assertEquals(1, List(u1, u2).sortUsablePositions(positions).length)
+  }
+
+  test("sort unusable positions") {
+    val positions = NonEmptyList.of(AgsPosition(Angle.Angle0, Offset.Zero),
+                                    AgsPosition(Angle.Angle180, Offset.Zero)
+    )
+    val u1        = Usable(
+      GuideProbe.OIWFS,
+      gs1,
+      GuideSpeed.Fast,
+      AgsGuideQuality.DeliversRequestedIq,
+      NonEmptyList.of(
+        AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
+      )
+    )
+    val u2        = NoMagnitudeForBand(
+      GuideProbe.OIWFS,
+      gs1
+    )
+    assertEquals(1, List(u1, u2).sortUsablePositions(positions).length)
   }
 
   test("discard science target") {


### PR DESCRIPTION
A bug on the sorting logic makes the unusable candidates show up on the AGS results as many times as positions are tested

This PR fixes that problems and discard all the unusable targets

The results with respect to usable targets is the same as before but the volume is much less. This impacts the performance on explore for crowded fields