### PR TITLE
Changes in preparation for supporting guide stars in the ODB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val kittensVersion             = "3.0.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion       := "0.41"
+ThisBuild / tlBaseVersion       := "0.42"
 ThisBuild / tlCiReleaseBranches := Seq("master", "scala3")
 
 ThisBuild / scalaVersion       := "3.3.0"

--- a/modules/ags/src/main/scala/lucuma/ags/Ags.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/Ags.scala
@@ -103,7 +103,7 @@ object Ags {
              guideStar,
              guideSpeed,
              quality,
-             NonEmptyList.one((position, vignettingArea(gsOffset)))
+             NonEmptyList.one((position.posAngle, vignettingArea(gsOffset)))
       )
     }
 

--- a/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsAnalysis.scala
@@ -105,7 +105,7 @@ object AgsAnalysis {
     target:               GuideStarCandidate,
     guideSpeed:           GuideSpeed,
     override val quality: AgsGuideQuality,
-    vignetting:           NonEmptyList[(AgsPosition, Area)]
+    vignetting:           NonEmptyList[(Angle, Area)]
   ) extends AgsAnalysis
       derives Eq {
     override def message(withProbe: Boolean): String = {
@@ -147,7 +147,7 @@ object AgsAnalysis {
 
   extension (analysis: AgsAnalysis)
     def posAngle: Option[Angle] = analysis match
-      case AgsAnalysis.Usable(_, _, _, _, v) => Some(v.head._1.posAngle)
+      case AgsAnalysis.Usable(_, _, _, _, v) => Some(v.head._1)
       case _                                 => None
 
   extension (analysis: Option[AgsAnalysis])
@@ -160,7 +160,7 @@ object AgsAnalysis {
      *
      * Non usable positions wii be discarded.
      */
-    def sortUsablePositions(positions: NonEmptyList[AgsPosition]): List[AgsAnalysis] = {
+    def sortUsablePositions: List[AgsAnalysis] = {
       val usablePerTarget: List[AgsAnalysis] =
         results
           .groupBy(_.target.id)

--- a/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
@@ -51,7 +51,7 @@ object AgsParams:
     port: PortDisposition
   ) extends AgsParams
       derives Eq:
-    val probe = GuideProbe.OIWFS
+    val probe = GuideProbe.GmosOiwfs
 
     def posCalculations(
       positions: NonEmptyList[AgsPosition]

--- a/modules/ags/src/main/scala/lucuma/ags/GuideProbe.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/GuideProbe.scala
@@ -9,6 +9,4 @@ import lucuma.core.util.Enumerated
  * Enumerated type for guide probe
  */
 enum GuideProbe(private val tag: String) derives Enumerated:
-  case AOWFS extends GuideProbe("AOWFS")
-  case OIWFS extends GuideProbe("OIWFS")
-  case PWFS  extends GuideProbe("PWFS")
+  case GmosOiwfs extends GuideProbe("GmosOiwfs")

--- a/modules/ags/src/main/scala/lucuma/ags/GuideStarCandidate.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/GuideStarCandidate.scala
@@ -14,11 +14,13 @@ import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.catalog.BandsList
 import lucuma.core.enums.Band
+import lucuma.core.enums.CatalogName
 import lucuma.core.math.BrightnessUnits.*
 import lucuma.core.math.BrightnessValue
 import lucuma.core.math.Epoch
 import lucuma.core.math.dimensional.*
 import lucuma.core.math.units.*
+import lucuma.core.model.CatalogInfo
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.SourceProfile
 import lucuma.core.model.SpectralDefinition
@@ -107,7 +109,7 @@ object GuideStarCandidate {
               )
             )
           ),
-          none
+          CatalogInfo(CatalogName.Gaia, g.id.toString)
         )
     )
 }

--- a/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
@@ -141,8 +141,8 @@ object AgsSelectionSampleApp extends IOApp.Simple with AgsSelectionSample {
                 ),
                 candidates
               )
-            println(s"Results ${r.sortUsablePositions(positions)}")
-            r.sortUsablePositions(positions)
+            println(s"Results ${r.sortUsablePositions}")
+            r.sortUsablePositions
           }
       )
       .flatTap(x => IO.println(x.length))

--- a/modules/tests/shared/src/test/scala/lucuma/ags/AgsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/ags/AgsSuite.scala
@@ -29,65 +29,61 @@ class AgsSuite extends munit.FunSuite {
   )
   test("usable comparisons") {
     val u1 = Usable(
-      GuideProbe.OIWFS,
+      GuideProbe.GmosOiwfs,
       gs1,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
+        Angle.Angle0 -> Area.fromMicroarcsecondsSquared.getOption(0).get
       )
     )
     val u2 = Usable(
-      GuideProbe.OIWFS,
+      GuideProbe.GmosOiwfs,
       gs1,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(1).get
+        Angle.Angle0 -> Area.fromMicroarcsecondsSquared.getOption(1).get
       )
     )
     val u3 = Usable(
-      GuideProbe.OIWFS,
+      GuideProbe.GmosOiwfs,
       gs2,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
+        Angle.Angle0 -> Area.fromMicroarcsecondsSquared.getOption(0).get
       )
     )
     val u4 = Usable(
-      GuideProbe.OIWFS,
+      GuideProbe.GmosOiwfs,
       gs2,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(2).get
+        Angle.Angle0 -> Area.fromMicroarcsecondsSquared.getOption(2).get
       )
     )
 
     val u12 = Usable(
-      GuideProbe.OIWFS,
+      GuideProbe.GmosOiwfs,
       gs1,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle0, Offset.Zero)   -> Area.fromMicroarcsecondsSquared.getOption(0).get,
-        AgsPosition(Angle.Angle180, Offset.Zero) -> Area.fromMicroarcsecondsSquared
-          .getOption(10)
-          .get
+        Angle.Angle0   -> Area.fromMicroarcsecondsSquared.getOption(0).get,
+        Angle.Angle180 -> Area.fromMicroarcsecondsSquared.getOption(10).get
       )
     )
 
     val u22 = Usable(
-      GuideProbe.OIWFS,
+      GuideProbe.GmosOiwfs,
       gs2,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle0, Offset.Zero)   -> Area.fromMicroarcsecondsSquared.getOption(9).get,
-        AgsPosition(Angle.Angle180, Offset.Zero) -> Area.fromMicroarcsecondsSquared
-          .getOption(20)
-          .get
+        Angle.Angle0   -> Area.fromMicroarcsecondsSquared.getOption(9).get,
+        Angle.Angle180 -> Area.fromMicroarcsecondsSquared.getOption(20).get
       )
     )
 
@@ -103,69 +99,63 @@ class AgsSuite extends munit.FunSuite {
 
   test("sort by brightness") {
     val u1 = Usable(
-      GuideProbe.OIWFS,
+      GuideProbe.GmosOiwfs,
       gs1,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle180, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
+        Angle.Angle180 -> Area.fromMicroarcsecondsSquared.getOption(0).get
       )
     )
     val u2 = Usable(
-      GuideProbe.OIWFS,
+      GuideProbe.GmosOiwfs,
       gs2,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
+        Angle.Angle0 -> Area.fromMicroarcsecondsSquared.getOption(0).get
       )
     )
     assert(AgsAnalysis.rankingOrder.compare(u1, u2) > 0)
   }
 
   test("sort positions") {
-    val positions = NonEmptyList.of(AgsPosition(Angle.Angle0, Offset.Zero),
-                                    AgsPosition(Angle.Angle180, Offset.Zero)
-    )
-    val u1        = Usable(
-      GuideProbe.OIWFS,
+    val u1 = Usable(
+      GuideProbe.GmosOiwfs,
       gs1,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
+        Angle.Angle0 -> Area.fromMicroarcsecondsSquared.getOption(0).get
       )
     )
-    val u2        = Usable(
-      GuideProbe.OIWFS,
+    val u2 = Usable(
+      GuideProbe.GmosOiwfs,
       gs1,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle180, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(1).get
+        Angle.Angle180 -> Area.fromMicroarcsecondsSquared.getOption(1).get
       )
     )
-    assertEquals(1, List(u1, u2).sortUsablePositions(positions).length)
+    assertEquals(1, List(u1, u2).sortUsablePositions.length)
   }
 
   test("sort unusable positions") {
-    val positions = NonEmptyList.of(AgsPosition(Angle.Angle0, Offset.Zero),
-                                    AgsPosition(Angle.Angle180, Offset.Zero)
-    )
-    val u1        = Usable(
-      GuideProbe.OIWFS,
+    val u1 = Usable(
+      GuideProbe.GmosOiwfs,
       gs1,
       GuideSpeed.Fast,
       AgsGuideQuality.DeliversRequestedIq,
       NonEmptyList.of(
-        AgsPosition(Angle.Angle0, Offset.Zero) -> Area.fromMicroarcsecondsSquared.getOption(0).get
+        Angle.Angle0 -> Area.fromMicroarcsecondsSquared.getOption(0).get
       )
     )
-    val u2        = NoMagnitudeForBand(
-      GuideProbe.OIWFS,
+    val u2 = NoMagnitudeForBand(
+      GuideProbe.GmosOiwfs,
       gs1
     )
-    assertEquals(1, List(u1, u2).sortUsablePositions(positions).length)
+    assertEquals(1, List(u1, u2).sortUsablePositions.length)
   }
 
   test("discard science target") {


### PR DESCRIPTION
- Removes unused parameter from `AgsAnalysis.sortUsablePositions`
- `Usable.vignetting` contains only the position angle - the offset was remove because it is used in the calculation but not the output.
- `CatalogInfo` was added to `Target.Sidereal` created from the `GuideStarCandidate`.
- The GuideProbe enum was modified, renaming the `IOWFS` to be more specific and removing unused values.