### PR TITLE
Add gaia query by source id

### DIFF
--- a/modules/catalog/src/main/scala/lucuma/catalog/votable/GaiaSourceIdQuery.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/votable/GaiaSourceIdQuery.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.catalog.votable
+
+trait GaiaSourceIdQuery:
+
+  def idQueryString(id: Long)(using gaia: CatalogAdapter.Gaia): String =
+    val fields = gaia.allFields.map(_.id.value.toLowerCase).mkString(",")
+    f"""|SELECT $fields
+      |     FROM ${gaia.gaiaDB}
+      |     WHERE source_id = $id
+    """.stripMargin
+
+object GaiaSourceIdQuery extends GaiaSourceIdQuery


### PR DESCRIPTION
I went with a simpler approach rather than using an `Interpreter` layer and all of that. So, it currently doesn't support things like `extraFields` that are in the `ADQLInterpreter`. If these seem important, I could augment the PR.