### PR TITLE
Update sbt-lucuma to 0.12.2, fix bundleMon

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,7 @@ lazy val catalog = crossProject(JVMPlatform, JSPlatform)
     ),
     scalacOptions ~= (_.filterNot(Set("-Vtype-diffs")))
   )
+  .jsConfigure(_.enablePlugins(BundleMonPlugin))
 
 lazy val ags = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
@@ -73,6 +74,7 @@ lazy val ags = crossProject(JVMPlatform, JSPlatform)
     ),
     scalacOptions ~= (_.filterNot(Set("-Vtype-diffs")))
   )
+  .jsConfigure(_.enablePlugins(BundleMonPlugin))
   .dependsOn(catalog)
 
 lazy val testkit = crossProject(JVMPlatform, JSPlatform)
@@ -119,7 +121,6 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
       new NodeJSEnv(NodeJSEnv.Config().withArgs(List("--experimental-fetch")))
     }
   )
-  .jsConfigure(_.enablePlugins(BundleMonPlugin))
   .jvmSettings(
     libraryDependencies ++= Seq(
       "co.fs2"     %% "fs2-io"                 % fs2Version,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers ++= Resolver.sonatypeOssRepos("public")
 resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib" % "0.12.1")
+addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib" % "0.12.2")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"    % "0.6.4")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"        % "0.4.7")


### PR DESCRIPTION
Removes bundleMon from `tests` and adds it to `ags` and `catalog`