### PR TITLE
Require non-zero duration to compute average PA

### DIFF
--- a/modules/ags/src/main/scala/lucuma/ags/package.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/package.scala
@@ -147,6 +147,7 @@ extension (posAngleConstraint: PosAngleConstraint)
   ): Option[NonEmptyList[Angle]] =
     TimeSpan
       .fromDuration(duration)
+      .filter(_ > TimeSpan.Zero)
       .flatMap: ts =>
         posAngleConstraint match
           case PosAngleConstraint.Fixed(a)               => NonEmptyList.of(a).some


### PR DESCRIPTION
On a completed sequence, `duration` is zero, which caused the computation to crash.