### PR TITLE
Change ags selection and sorting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,11 +24,11 @@ lazy val kittensVersion             = "3.5.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion       := "0.49"
+ThisBuild / tlBaseVersion       := "0.50"
 ThisBuild / tlCiReleaseBranches := Seq("master", "scala3")
 
-ThisBuild / scalaVersion       := "3.6.3"
-ThisBuild / crossScalaVersions := Seq("3.6.3")
+ThisBuild / scalaVersion       := "3.6.4"
+ThisBuild / crossScalaVersions := Seq("3.6.4")
 ThisBuild / scalacOptions ++= Seq(
   "-language:implicitConversions"
 )

--- a/modules/benchmarks/src/main/scala/lucuma/catalog/votable/AgsBenchmark.scala
+++ b/modules/benchmarks/src/main/scala/lucuma/catalog/votable/AgsBenchmark.scala
@@ -47,7 +47,7 @@ class AgsBenchmark extends AgsSelectionSample {
       coords,
       List(coords),
       positions,
-      params,
+      gmosParams,
       items
     )
     ()
@@ -61,7 +61,7 @@ class AgsBenchmark extends AgsSelectionSample {
       _ => coords.some,
       List(_ => coords.some),
       positions,
-      params,
+      gmosParams,
       Instant.now(),
       items
     )
@@ -70,11 +70,11 @@ class AgsBenchmark extends AgsSelectionSample {
 
   @Benchmark
   def magnitudeAnalysis: Unit = {
-    val geoms  = params.posCalculations(NonEmptyList.one(positions.head))
+    val geoms  = gmosParams.posCalculations(NonEmptyList.one(positions.head))
     val limits = Ags.guideSpeedLimits(constraints, wavelength)
     Ags.magnitudeAnalysis(
       constraints,
-      params.probe,
+      gmosParams.probe,
       Offset.Zero,
       items.head,
       geoms.get(0).get.vignettingArea(_),

--- a/modules/catalog/src/main/scala/lucuma/catalog/csv/TargetImport.scala
+++ b/modules/catalog/src/main/scala/lucuma/catalog/csv/TargetImport.scala
@@ -12,7 +12,6 @@ import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.types.string.NonEmptyString
 import fs2.*
 import fs2.data.csv.*
-import fs2.text
 import lucuma.catalog.*
 import lucuma.catalog.votable.CatalogAdapter
 import lucuma.catalog.votable.CatalogSearch

--- a/modules/testkit/src/main/scala/lucuma/catalog/votable/arb/ArbFieldId.scala
+++ b/modules/testkit/src/main/scala/lucuma/catalog/votable/arb/ArbFieldId.scala
@@ -8,7 +8,6 @@ import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.catalog.votable.*
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Cogen
 
 trait ArbFieldId {
   import ArbUcd.given

--- a/modules/testkit/src/main/scala/lucuma/catalog/votable/arb/ArbUcd.scala
+++ b/modules/testkit/src/main/scala/lucuma/catalog/votable/arb/ArbUcd.scala
@@ -8,8 +8,6 @@ import eu.timepit.refined.scalacheck.string.*
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.catalog.votable.*
 import org.scalacheck.*
-import org.scalacheck.Cogen
-import org.scalacheck.Gen
 
 trait ArbUcd {
   val genNonEmptyString = summon[Arbitrary[NonEmptyString]].arbitrary

--- a/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
@@ -9,7 +9,6 @@ import cats.effect.IOApp
 import cats.effect.Sync
 import cats.syntax.all.*
 import fs2.*
-import fs2.text
 import lucuma.ags.*
 import lucuma.catalog.votable.*
 import lucuma.core.enums.CloudExtinction


### PR DESCRIPTION
The old algorithm was allowing targets that were not valid at some offsets to be selected. And the sorting by vignetting was sometimes off because it sorted by the best vignetting of any offset at the given angle, so target could get selected first even if it vignetted at some offsets while another target did not vignette at all.

See comment for `AgsAnalysis.sortUsablePositions` for more details.

I also updated to scala 3.6.4 since I saw a PR for that was failing in CI due to unused imports.